### PR TITLE
configure: fix with-network default case

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -83,7 +83,7 @@ case $hsk_network in
     AC_DEFINE(HSK_NETWORK, HSK_MAIN,
       [Define this symbol to choose a network])
   ;;
-  testnet)
+  testnet | yes)
     AC_DEFINE(HSK_NETWORK, HSK_TESTNET,
       [Define this symbol to choose a network])
   ;;


### PR DESCRIPTION
Using the --with-network switch without an argument
as suggested in the install instructions,
has a default value of "yes" set by automake.
Consider that as a valid value for the
"testnet" case as well which is our intended default.