### PR TITLE
Windows support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -19,7 +19,8 @@ CLEANFILES =
 
 lib_LTLIBRARIES = libhsk.la
 
-libhsk_la_LIBADD = $(top_builddir)/uv/libuv.la
+libhsk_la_LIBADD = $(top_builddir)/uv/libuv.la   \
+                   $(LIB_WINBCRYPT)
 
 libhsk_la_CFLAGS = -DHSK_BUILD @CFLAGS@
 libhsk_la_LDFLAGS = -no-undefined -version-info 0:0:0

--- a/Makefile.am
+++ b/Makefile.am
@@ -67,7 +67,8 @@ hnsd_SOURCES = src/cache.c  \
                src/daemon.c \
                src/ns.c     \
                src/rs.c     \
-               src/rs_worker.c
+               src/rs_worker.c \
+               src/signals.c
 
 hnsd_LDADD = $(LIB_UNBOUND)             \
              $(top_builddir)/libhsk.la

--- a/Makefile.am
+++ b/Makefile.am
@@ -67,11 +67,11 @@ hnsd_SOURCES = src/cache.c  \
                src/ns.c     \
                src/rs.c
 
-hnsd_LDADD = -lunbound                  \
+hnsd_LDADD = $(LIB_UNBOUND)             \
              $(top_builddir)/libhsk.la
 
 hnsd_LDFLAGS = -static
-hnsd_CFLAGS = -DHSK_BUILD $(AM_CFLAGS)
+hnsd_CFLAGS = -DHSK_BUILD $(INC_UNBOUND) $(AM_CFLAGS)
 hnsd_CPPFLAGS = $(AM_CPPFLAGS)
 
 # pkgconfigdir = $(libdir)/pkgconfig

--- a/Makefile.am
+++ b/Makefile.am
@@ -66,7 +66,8 @@ noinst_PROGRAMS = $(PROGS)
 hnsd_SOURCES = src/cache.c  \
                src/daemon.c \
                src/ns.c     \
-               src/rs.c
+               src/rs.c     \
+               src/rs_worker.c
 
 hnsd_LDADD = $(LIB_UNBOUND)             \
              $(top_builddir)/libhsk.la

--- a/README.md
+++ b/README.md
@@ -90,6 +90,23 @@ You're a Linux user so you probably already know what to do. Make sure you have
 git, autotools, libtool, and unbound installed via whatever package manager
 your OS uses.
 
+### Windows
+
+Windows builds are made natively with MSYS2 / MinGW.  This uses the MinGW
+libunbound and OpenSSL packages provided by MSYS2.
+
+1. Install MSYS2 from https://www.msys2.org - follow the instructions on that page
+2. Install dependencies - do one of the following in an MSYS2 shell
+   - x86_64: `pacman -S base-devel mingw-w64-x86_64-toolchain mingw-w64-x86_64-unbound mingw-w64-x86_64-crt-git`
+   - x86: `pacman -S base-devel mingw-w64-i686-toolchain mingw-w64-i686-unbound mingw-w64-i686-crt-git`
+3. (Optional) You can install git if you want to use it from the MSYS2 shell - `pacman -S git`
+   - Git for Windows works fine too but avoid mixing the two, they may not handle line endings the same way
+4. Then build normally from the MSYS2 shell.
+
+The Windows build will dynamically link to the MinGW libunbound and OpenSSL DLLs.
+You can run it from the MSYS2 shell, which sets PATH appropriately, copy those
+DLLs to the hnsd directory, etc.
+
 ## Cloning
 
 ``` sh

--- a/configure.ac
+++ b/configure.ac
@@ -338,6 +338,13 @@ esac
 AC_SUBST(LIB_UNBOUND, ${LIB_UNBOUND})
 AC_SUBST(INC_UNBOUND, ${INC_UNBOUND})
 
+dnl Platform-specific libraries
+case "${host_os}" in
+  mingw*)
+    AC_SUBST(LIB_WINBCRYPT, "-lbcrypt")
+    ;;
+esac
+
 AC_MSG_NOTICE([Using endomorphism optimizations: $use_endomorphism])
 AC_MSG_NOTICE([Using static precomputation: $use_precomp])
 AC_MSG_NOTICE([Using assembly optimizations: $set_asm])

--- a/configure.ac
+++ b/configure.ac
@@ -152,6 +152,14 @@ AC_ARG_WITH([asm],
   [req_asm=$withval],
   [req_asm=auto])
 
+AC_ARG_WITH([unbound],
+  [AS_HELP_STRING(
+    [--with-unbound=path]
+    [Use libunbound installed at path. Default is to search system paths.]
+  )],
+  [libunbound_path=$withval],
+  [libunbound_path=yes])
+
 AC_CHECK_TYPES([__int128])
 
 AC_MSG_CHECKING([for __builtin_expect])
@@ -309,11 +317,34 @@ if test x"$use_external_asm" = x"yes"; then
     [Define this symbol if an external assembly implementation is used])
 fi
 
+dnl Find libunbound, and define LIB_UNBOUND/INC_UNBOUND for hnsd.
+dnl Don't add these to the default libs/includes, they're not needed by the
+dnl other targets.
+case $libunbound_path in
+  no)
+    AC_MSG_ERROR([libunbound is required])
+    ;;
+  yes)
+    AC_CHECK_LIB(unbound, ub_ctx_create, LIB_UNBOUND="-lunbound",
+      AC_MSG_ERROR([Unable to find libunbound]))
+    AC_CHECK_HEADER(unbound.h, INC_UNBOUND="",
+      AC_MSG_ERROR([Unable to found unbound.h]))
+    ;;
+  *)
+    LIB_UNBOUND="-L${libunbound_path}/lib -lunbound"
+    INC_UNBOUND="-I${libunbound_path}/include"
+    ;;
+esac
+AC_SUBST(LIB_UNBOUND, ${LIB_UNBOUND})
+AC_SUBST(INC_UNBOUND, ${INC_UNBOUND})
+
 AC_MSG_NOTICE([Using endomorphism optimizations: $use_endomorphism])
 AC_MSG_NOTICE([Using static precomputation: $use_precomp])
 AC_MSG_NOTICE([Using assembly optimizations: $set_asm])
 AC_MSG_NOTICE([Using field implementation: $set_field])
 AC_MSG_NOTICE([Using scalar implementation: $set_scalar])
+AC_MSG_NOTICE([Linker flags for libunbound: $LIB_UNBOUND])
+AC_MSG_NOTICE([Compiler flags for libunbound: $INC_UNBOUND])
 
 AM_CONDITIONAL(
   [HSK_USE_ECMULT_STATIC_PRECOMPUTATION],

--- a/src/addr.c
+++ b/src/addr.c
@@ -5,8 +5,6 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <arpa/inet.h>
-#include <netinet/in.h>
 #include <string.h>
 
 #include "addr.h"
@@ -14,6 +12,7 @@
 #include "bio.h"
 #include "constants.h"
 #include "map.h"
+#include "platform-net.h"
 #include "uv.h"
 
 static const uint8_t hsk_ip4_mapped[12] = {

--- a/src/addr.h
+++ b/src/addr.h
@@ -6,8 +6,8 @@
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <arpa/inet.h>
-#include <netinet/in.h>
+
+#include "platform-net.h"
 
 // INET6_ADDRSTRLEN = 65
 // 65 + 5 + 1 + 2 = 73 - long enough for [ipv6]:port

--- a/src/addrmgr.c
+++ b/src/addrmgr.c
@@ -4,8 +4,6 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdarg.h>
-#include <arpa/inet.h>
-#include <netinet/in.h>
 #include <math.h>
 
 #include "addr.h"
@@ -13,6 +11,7 @@
 #include "constants.h"
 #include "error.h"
 #include "map.h"
+#include "platform-net.h"
 #include "seeds.h"
 #include "timedata.h"
 #include "utils.h"

--- a/src/addrmgr.h
+++ b/src/addrmgr.h
@@ -4,12 +4,11 @@
 #include <assert.h>
 #include <stdint.h>
 #include <stdbool.h>
-#include <arpa/inet.h>
-#include <netinet/in.h>
 
 #include "addr.h"
 #include "timedata.h"
 #include "map.h"
+#include "platform-net.h"
 
 typedef struct hsk_addrentry_s {
   hsk_addr_t addr;

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -578,6 +578,12 @@ main(int argc, char **argv) {
 
   parse_arg(argc, argv, &opt);
 
+#ifndef _WIN32
+  // Ignore SIGPIPE, remotely closed sockets are handled and shouldn't kill
+  // hnsd.  (This happens a lot under Valgrind but can happen normally too.)
+  signal(SIGPIPE, SIG_IGN);
+#endif
+
   int rc = HSK_SUCCESS;
   uv_loop_t *loop = NULL;
   hsk_daemon_t daemon;

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -64,6 +64,8 @@ set_logfile(const char *logfile) {
 #endif
 }
 
+// --daemon is not supported under MinGW (no fork() syscall)
+#ifndef _WIN32
 static bool
 daemonize(const char *logfile) {
 #ifdef __linux
@@ -98,6 +100,7 @@ daemonize(const char *logfile) {
 
   return true;
 }
+#endif
 
 static void
 help(int r) {
@@ -137,9 +140,11 @@ help(int r) {
     "  -l, --log-file <filename>\n"
     "    Redirect output to a log file.\n"
     "\n"
+#ifndef _WIN32
     "  -d, --daemon\n"
     "    Fork and background the process.\n"
     "\n"
+#endif
     "  -h, --help\n"
     "    This help message.\n"
     "\n"
@@ -150,7 +155,11 @@ help(int r) {
 
 static void
 parse_arg(int argc, char **argv, hsk_options_t *opt) {
-  const static char *optstring = "c:n:r:i:u:p:k:s:l:dh";
+  const static char *optstring = "c:n:r:i:u:p:k:s:l:h"
+#ifndef _WIN32
+    "d"
+#endif
+    ;
 
   const static struct option longopts[] = {
     { "config", required_argument, NULL, 'c' },
@@ -162,14 +171,18 @@ parse_arg(int argc, char **argv, hsk_options_t *opt) {
     { "identity-key", required_argument, NULL, 'k' },
     { "seeds", required_argument, NULL, 's' },
     { "log-file", required_argument, NULL, 'l' },
+#ifndef _WIN32
     { "daemon", no_argument, NULL, 'd' },
+#endif
     { "help", no_argument, NULL, 'h' }
   };
 
   int longopt_idx = -1;
   bool has_ip = false;
   char *logfile = NULL;
+#ifndef _WIN32
   bool background = false;
+#endif
 
   optind = 1;
 
@@ -293,10 +306,12 @@ parse_arg(int argc, char **argv, hsk_options_t *opt) {
         break;
       }
 
+#ifndef _WIN32
       case 'd': {
         background = true;
         break;
       }
+#endif
 
       case '?': {
         return help(1);
@@ -310,10 +325,15 @@ parse_arg(int argc, char **argv, hsk_options_t *opt) {
   if (!has_ip)
     hsk_sa_copy(opt->ns_ip, opt->ns_host);
 
+#ifndef _WIN32
   if (background)
     daemonize(logfile);
-  else if (logfile)
-    set_logfile(logfile);
+  else
+#endif
+  {
+    if (logfile)
+      set_logfile(logfile);
+  }
 
   if (logfile)
     free(logfile);

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -8,8 +8,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
-#include <arpa/inet.h>
-#include <netinet/in.h>
 #include <getopt.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -19,6 +17,7 @@
 #include "ns.h"
 #include "rs.h"
 #include "uv.h"
+#include "platform-net.h"
 
 extern char *optarg;
 extern int optind, opterr, optopt;

--- a/src/ns.c
+++ b/src/ns.c
@@ -8,8 +8,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
-#include <arpa/inet.h>
-#include <netinet/in.h>
 
 #include "addr.h"
 #include "cache.h"
@@ -22,6 +20,7 @@
 #include "pool.h"
 #include "req.h"
 #include "tld.h"
+#include "platform-net.h"
 #include "uv.h"
 
 /*

--- a/src/ns.c
+++ b/src/ns.c
@@ -21,6 +21,7 @@
 #include "req.h"
 #include "tld.h"
 #include "platform-net.h"
+#include "utils.h"
 #include "uv.h"
 
 /*
@@ -101,14 +102,13 @@ hsk_ns_init(hsk_ns_t *ns, const uv_loop_t *loop, const hsk_pool_t *pool) {
   ns->pool = (hsk_pool_t *)pool;
   hsk_addr_init(&ns->ip_);
   ns->ip = NULL;
-  ns->socket.data = (void *)ns;
+  ns->socket = NULL;
   ns->ec = ec;
   hsk_cache_init(&ns->cache);
   memset(ns->key_, 0x00, sizeof(ns->key_));
   ns->key = NULL;
   memset(ns->pubkey, 0x00, sizeof(ns->pubkey));
   memset(ns->read_buffer, 0x00, sizeof(ns->read_buffer));
-  ns->bound = false;
   ns->receiving = false;
 
   return HSK_SUCCESS;
@@ -118,8 +118,6 @@ void
 hsk_ns_uninit(hsk_ns_t *ns) {
   if (!ns)
     return;
-
-  ns->socket.data = NULL;
 
   if (ns->ec) {
     hsk_ec_free(ns->ec);
@@ -175,25 +173,27 @@ hsk_ns_open(hsk_ns_t *ns, const struct sockaddr *addr) {
   if (!ns || !addr)
     return HSK_EBADARGS;
 
-  if (uv_udp_init(ns->loop, &ns->socket) != 0)
+  ns->socket = malloc(sizeof(uv_udp_t));
+  if (!ns->socket)
+    return HSK_ENOMEM;
+
+  if (uv_udp_init(ns->loop, ns->socket) != 0)
     return HSK_EFAILURE;
 
-  ns->socket.data = (void *)ns;
+  ns->socket->data = (void *)ns;
 
-  if (uv_udp_bind(&ns->socket, addr, 0) != 0)
+  if (uv_udp_bind(ns->socket, addr, 0) != 0)
     return HSK_EFAILURE;
-
-  ns->bound = true;
 
   int value = sizeof(ns->read_buffer);
 
-  if (uv_send_buffer_size((uv_handle_t *)&ns->socket, &value) != 0)
+  if (uv_send_buffer_size((uv_handle_t *)ns->socket, &value) != 0)
     return HSK_EFAILURE;
 
-  if (uv_recv_buffer_size((uv_handle_t *)&ns->socket, &value) != 0)
+  if (uv_recv_buffer_size((uv_handle_t *)ns->socket, &value) != 0)
     return HSK_EFAILURE;
 
-  if (uv_udp_recv_start(&ns->socket, alloc_buffer, after_recv) != 0)
+  if (uv_udp_recv_start(ns->socket, alloc_buffer, after_recv) != 0)
     return HSK_EFAILURE;
 
   ns->receiving = true;
@@ -215,17 +215,16 @@ hsk_ns_close(hsk_ns_t *ns) {
     return HSK_EBADARGS;
 
   if (ns->receiving) {
-    if (uv_udp_recv_stop(&ns->socket) != 0)
+    if (uv_udp_recv_stop(ns->socket) != 0)
       return HSK_EFAILURE;
     ns->receiving = false;
   }
 
-  if (ns->bound) {
-    uv_close((uv_handle_t *)&ns->socket, after_close);
-    ns->bound = false;
+  if (ns->socket) {
+    hsk_uv_close_free((uv_handle_t *)ns->socket);
+    ns->socket->data = NULL;
+    ns->socket = NULL;
   }
-
-  ns->socket.data = NULL;
 
   return HSK_SUCCESS;
 }
@@ -480,6 +479,11 @@ hsk_ns_send(
   hsk_send_data_t *sd = NULL;
   uv_udp_send_t *req = NULL;
 
+  if (!ns->socket) {
+    rc = HSK_EFAILURE;
+    goto fail;
+  }
+
   sd = (hsk_send_data_t *)malloc(sizeof(hsk_send_data_t));
 
   if (!sd) {
@@ -504,7 +508,7 @@ hsk_ns_send(
     { .base = (char *)data, .len = data_len }
   };
 
-  int status = uv_udp_send(req, &ns->socket, bufs, 1, addr, after_send);
+  int status = uv_udp_send(req, ns->socket, bufs, 1, addr, after_send);
 
   if (status != 0) {
     hsk_ns_log(ns, "failed sending: %s\n", uv_strerror(status));
@@ -600,9 +604,6 @@ after_recv(
     (uint32_t)flags
   );
 }
-
-static void
-after_close(uv_handle_t *handle) {}
 
 static void
 after_resolve(

--- a/src/ns.h
+++ b/src/ns.h
@@ -25,14 +25,13 @@ typedef struct {
   hsk_pool_t *pool;
   hsk_addr_t ip_;
   hsk_addr_t *ip;
-  uv_udp_t socket;
+  uv_udp_t *socket;
   hsk_ec_t *ec;
   hsk_cache_t cache;
   uint8_t key_[32];
   uint8_t *key;
   uint8_t pubkey[33];
   uint8_t read_buffer[HSK_UDP_BUFFER];
-  bool bound;
   bool receiving;
 } hsk_ns_t;
 

--- a/src/platform-net.h
+++ b/src/platform-net.h
@@ -1,0 +1,11 @@
+#ifndef _HSK_PLATFORMNET_H
+#define _HSK_PLATFORMNET_H
+
+#ifndef _WIN32
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#else
+#include <winsock2.h>
+#endif
+
+#endif

--- a/src/pool.c
+++ b/src/pool.c
@@ -108,7 +108,7 @@ static void
 after_write(uv_write_t *req, int status);
 
 static void
-after_read(uv_stream_t *stream, long int nread, const uv_buf_t *buf);
+after_read(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf);
 
 static void
 after_close(uv_handle_t *handle);
@@ -1719,7 +1719,7 @@ alloc_buffer(uv_handle_t *handle, size_t size, uv_buf_t *buf) {
 }
 
 static void
-after_read(uv_stream_t *stream, long int nread, const uv_buf_t *buf) {
+after_read(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf) {
   hsk_peer_t *peer = (hsk_peer_t *)stream->data;
 
   if (!peer)

--- a/src/pool.c
+++ b/src/pool.c
@@ -333,8 +333,6 @@ hsk_pool_close(hsk_pool_t *pool) {
   if (uv_timer_stop(&pool->timer) != 0)
     return HSK_EFAILURE;
 
-  hsk_pool_uninit(pool);
-
   return HSK_SUCCESS;
 }
 
@@ -342,6 +340,12 @@ int
 hsk_pool_destroy(hsk_pool_t *pool) {
   if (!pool)
     return HSK_EBADARGS;
+
+  int rc = hsk_pool_close(pool);
+  if (rc != HSK_SUCCESS) {
+    hsk_pool_log(pool, "failed to close pool: %s\n", hsk_strerror(rc));
+    return rc;
+  }
 
   hsk_pool_free(pool);
 

--- a/src/pool.c
+++ b/src/pool.c
@@ -159,6 +159,7 @@ hsk_pool_init(hsk_pool_t *pool, const uv_loop_t *loop) {
   hsk_timedata_init(&pool->td);
   hsk_chain_init(&pool->chain, &pool->td);
   hsk_addrman_init(&pool->am, &pool->td);
+  pool->timer = NULL;
   pool->peer_id = 0;
   hsk_map_init_map(&pool->peers, hsk_addr_hash, hsk_addr_equal, NULL);
   pool->head = NULL;
@@ -310,12 +311,16 @@ hsk_pool_open(hsk_pool_t *pool) {
   if (!pool)
     return HSK_EBADARGS;
 
-  pool->timer.data = (void *)pool;
+  pool->timer = malloc(sizeof(uv_timer_t));
+  if (!pool->timer)
+    return HSK_ENOMEM;
 
-  if (uv_timer_init(pool->loop, &pool->timer) != 0)
+  pool->timer->data = (void *)pool;
+
+  if (uv_timer_init(pool->loop, pool->timer) != 0)
     return HSK_EFAILURE;
 
-  if (uv_timer_start(&pool->timer, after_timer, 3000, 3000) != 0)
+  if (uv_timer_start(pool->timer, after_timer, 3000, 3000) != 0)
     return HSK_EFAILURE;
 
   hsk_pool_log(pool, "pool opened (size=%u)\n", pool->max_size);
@@ -330,8 +335,11 @@ hsk_pool_close(hsk_pool_t *pool) {
   if (!pool)
     return HSK_EBADARGS;
 
-  if (uv_timer_stop(&pool->timer) != 0)
+  if (uv_timer_stop(pool->timer) != 0)
     return HSK_EFAILURE;
+
+  hsk_uv_close_free((uv_handle_t*)pool->timer);
+  pool->timer = NULL;
 
   return HSK_SUCCESS;
 }

--- a/src/pool.h
+++ b/src/pool.h
@@ -94,7 +94,7 @@ typedef struct hsk_pool_s {
   hsk_timedata_t td;
   hsk_chain_t chain;
   hsk_addrman_t am;
-  uv_timer_t timer;
+  uv_timer_t *timer;
   uint64_t peer_id;
   hsk_map_t peers;
   hsk_peer_t *head;

--- a/src/random.c
+++ b/src/random.c
@@ -79,33 +79,6 @@ hsk_randombytes(uint8_t *dst, size_t len) {
 }
 
 #elif defined(_WIN16) || defined(_WIN32) || defined(_WIN64)
-
-#if defined(HAVE_WINCRYPT_H)
-#define WIN32_LEAN_AND_MEAN
-#include <windows.h>
-#include <wincrypt.h>
-
-bool
-hsk_randombytes(uint8_t *dst, size_t len) {
-  HCRYPTPROV prov;
-
-  BOOL r = CryptAcquireContext(
-    &prov,
-    NULL,
-    NULL,
-    PROV_RSA_FULL,
-    CRYPT_VERIFYCONTEXT
-  );
-
-  if (!r)
-    return false;
-
-  CryptGenRandom(prov, len, (BYTE *)dst);
-  CryptReleaseContext(prov, 0);
-
-  return true;
-}
-#else
 #include <windows.h>
 
 bool
@@ -117,7 +90,6 @@ hsk_randombytes(uint8_t *dst, size_t len) {
 
   return true;
 }
-#endif
 
 #else
 

--- a/src/req.h
+++ b/src/req.h
@@ -5,11 +5,10 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>
-#include <arpa/inet.h>
-#include <netinet/in.h>
 
 #include "dns.h"
 #include "ec.h"
+#include "platform-net.h"
 
 typedef struct {
   // Reference.

--- a/src/rs.c
+++ b/src/rs.c
@@ -8,9 +8,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <time.h>
-#include <arpa/inet.h>
-#include <netinet/in.h>
-
 #include <unbound.h>
 
 #include "addr.h"
@@ -19,6 +16,7 @@
 #include "dnssec.h"
 #include "ec.h"
 #include "error.h"
+#include "platform-net.h"
 #include "resource.h"
 #include "req.h"
 #include "rs.h"

--- a/src/rs.c
+++ b/src/rs.c
@@ -64,113 +64,11 @@ after_recv(
   unsigned flags
 );
 
-// Resolve callback on libunbound worker thread.
 static void
-after_resolve_onthread(void *data, int status, struct ub_result *result);
-
-// Resolve async event handler in libuv event loop.
-static void
-after_resolve(uv_async_t *async);
+after_resolve(void *data, int status, struct ub_result *result);
 
 static void
 after_close(uv_handle_t *handle);
-
-static void
-after_close_free(uv_handle_t *handle);
-
-static void
-run_unbound_worker(void *arg);
-
-static void
-after_resolve_shutdown(void *data, int status, struct ub_result *result);
-
-/*
- * Response Queue
- */
-int
-hsk_rs_queue_init(hsk_rs_queue_t *queue) {
-  if (uv_mutex_init(&queue->mutex))
-    return HSK_EFAILURE;
-  queue->head = NULL;
-  queue->tail = NULL;
-
-  return HSK_SUCCESS;
-}
-
-void
-hsk_rs_queue_uninit(hsk_rs_queue_t *queue) {
-  hsk_rs_rsp_t *current = queue->head;
-  while (current) {
-    hsk_rs_rsp_t *next = current->next;
-    free(current);
-    current = next;
-  }
-
-  uv_mutex_destroy(&queue->mutex);
-}
-
-hsk_rs_queue_t *hsk_rs_queue_alloc() {
-  hsk_rs_queue_t *queue = malloc(sizeof(hsk_rs_queue_t));
-  if(!queue)
-    return NULL;
-
-  if (hsk_rs_queue_init(queue) != HSK_SUCCESS) {
-    free(queue);
-    return NULL;
-  }
-
-  return queue;
-}
-
-void hsk_rs_queue_free(hsk_rs_queue_t *queue) {
-  if(!queue)
-    return;
-
-  hsk_rs_queue_uninit(queue);
-  free(queue);
-}
-
-// Dequeue the oldest queued response - thread-safe.
-// Returned object is now owned by the caller; returns nullptr if there is
-// nothing queued.
-hsk_rs_rsp_t *
-hsk_rs_queue_dequeue(hsk_rs_queue_t *queue) {
-  uv_mutex_lock(&queue->mutex);
-
-  hsk_rs_rsp_t *oldest = queue->head;
-  if (oldest) {
-    queue->head = oldest->next;
-    oldest->next = NULL;
-    // If this was the only queued request, clear tail too
-    if(queue->tail == oldest)
-      queue->tail = NULL;
-  }
-
-  uv_mutex_unlock(&queue->mutex);
-
-  return oldest;
-}
-
-// Enqueue a response - thread-safe.
-// The queue takes ownership of the response (until it's popped off again).
-void
-hsk_rs_queue_enqueue(hsk_rs_queue_t *queue, hsk_rs_rsp_t *rsp) {
-  uv_mutex_lock(&queue->mutex);
-
-  if (!queue->tail) {
-    // There were no requests queued; this one becomes head and tail
-    assert(!queue->head);   // Invariant - set and cleared together
-    queue->head = rsp;
-    queue->tail = rsp;
-  }
-  else {
-    // There are requests queued already, add this one to the tail
-    queue->tail->next = rsp;
-    queue->tail = rsp;
-  }
-
-  uv_mutex_unlock(&queue->mutex);
-}
 
 /*
  * Recursive NS
@@ -184,8 +82,6 @@ hsk_rs_init(hsk_rs_t *ns, const uv_loop_t *loop, const struct sockaddr *stub) {
   int err = HSK_ENOMEM;
   struct ub_ctx *ub = NULL;
   hsk_ec_t *ec = NULL;
-  hsk_rs_queue_t *rs_queue = NULL;
-  uv_async_t *rs_async = NULL;
 
   ub = ub_ctx_create();
 
@@ -193,16 +89,6 @@ hsk_rs_init(hsk_rs_t *ns, const uv_loop_t *loop, const struct sockaddr *stub) {
     goto fail;
 
   if (ub_ctx_async(ub, 1) != 0)
-    goto fail;
-
-  rs_queue = hsk_rs_queue_alloc();
-
-  if (!rs_queue)
-    goto fail;
-
-  // Allocate this separately on the heap because uv_close() is asynchronous.
-  rs_async = malloc(sizeof(uv_async_t));
-  if (!rs_async || uv_async_init((uv_loop_t*)loop, rs_async, after_resolve))
     goto fail;
 
   ec = hsk_ec_alloc();
@@ -213,9 +99,7 @@ hsk_rs_init(hsk_rs_t *ns, const uv_loop_t *loop, const struct sockaddr *stub) {
   ns->loop = (uv_loop_t *)loop;
   ns->ub = ub;
   ns->socket.data = (void *)ns;
-  ns->rs_queue = rs_queue;
-  ns->rs_async = rs_async;
-  ns->rs_async->data = (void *)ns;
+  ns->rs_worker = NULL;
   ns->ec = ec;
   ns->config = NULL;
   ns->stub = (struct sockaddr *)&ns->stub_;
@@ -226,7 +110,6 @@ hsk_rs_init(hsk_rs_t *ns, const uv_loop_t *loop, const struct sockaddr *stub) {
   memset(ns->read_buffer, 0x00, sizeof(ns->read_buffer));
   ns->bound = false;
   ns->receiving = false;
-  ns->rs_worker_running = false;
 
   if (stub) {
     err = HSK_EFAILURE;
@@ -243,12 +126,6 @@ hsk_rs_init(hsk_rs_t *ns, const uv_loop_t *loop, const struct sockaddr *stub) {
 fail:
   if (ub)
     ub_ctx_delete(ub);
-
-  if (rs_queue)
-    hsk_rs_queue_free(rs_queue);
-
-  if (rs_async)
-    free(rs_async);
 
   if (ec)
     hsk_ec_free(ec);
@@ -271,21 +148,6 @@ hsk_rs_uninit(hsk_rs_t *ns) {
   if (ns->ub) {
     ub_ctx_delete(ns->ub);
     ns->ub = NULL;
-  }
-
-  // Free the response event and queue after destroying the unbound context.
-  // The libunbound worker has now stopped, so we can safely free these.
-  if (ns->rs_async) {
-    ns->rs_async->data = NULL;
-    // We have to free this object in the callback, libuv specifically says it
-    // must not be freed before the callback occurs
-    uv_close((uv_handle_t *)ns->rs_async, after_close_free);
-    ns->rs_async = NULL;
-  }
-
-  if (ns->rs_queue) {
-    hsk_rs_queue_free(ns->rs_queue);
-    ns->rs_queue = NULL;
   }
 
   if (ns->config) {
@@ -419,11 +281,9 @@ hsk_rs_open(hsk_rs_t *ns, const struct sockaddr *addr) {
 
   ns->receiving = true;
 
-  ns->rs_worker_running = true;
-  if (uv_thread_create(&ns->rs_worker, run_unbound_worker, (void *)ns) != 0) {
-    ns->rs_worker_running = false;
+  ns->rs_worker = hsk_rs_worker_alloc(ns->loop, ns->ub);
+  if (!ns->rs_worker)
     return HSK_EFAILURE;
-  }
 
   char host[HSK_MAX_HOST];
   assert(hsk_sa_to_string(addr, host, HSK_MAX_HOST, HSK_NS_PORT));
@@ -438,23 +298,9 @@ hsk_rs_close(hsk_rs_t *ns) {
   if (!ns)
     return HSK_EBADARGS;
 
-  if (ns->rs_worker_running) {
-    // We need to tell the libunbound worker to exit - wake up the thread and
-    // clear rs_worker_running on that thread.
-    //
-    // libunbound doesn't give us a good way to do this, the only way is to
-    // issue a dummy query and do this in the callback on the worker thread.
-    //
-    // On Unix, we could poll unbound's file descriptor manually with another
-    // file descriptor to allow us to wake the thread here.  On Windows though,
-    // libunbound does not provide any access to its WSAEVENT to do the same
-    // thing.
-    int rc = ub_resolve_async(ns->ub, ".", HSK_DNS_NS, HSK_DNS_IN, (void *)ns,
-                              after_resolve_shutdown, NULL);
-    if(rc != 0)
-      hsk_rs_log(ns, "cannot shut down worker thread: %s\n", ub_strerror(rc));
-    else
-      uv_thread_join(&ns->rs_worker);
+  if (ns->rs_worker) {
+    hsk_rs_worker_free(ns->rs_worker);
+    ns->rs_worker = NULL;
   }
 
   if (ns->receiving) {
@@ -556,20 +402,19 @@ hsk_rs_onrecv(
     goto fail;
   }
 
-  rc = ub_resolve_async(
-    ns->ub,
+  rc = hsk_rs_worker_resolve(
+    ns->rs_worker,
     req->name,
     req->type,
     req->class,
     (void *)req,
-    after_resolve_onthread,
-    NULL
+    after_resolve
   );
 
-  if (rc == 0)
+  if (rc == HSK_SUCCESS)
     return;
 
-  hsk_rs_log(ns, "unbound error: %s\n", ub_strerror(rc));
+  hsk_rs_log(ns, "resolve error: %s\n", hsk_strerror(rc));
 
   msg = hsk_resource_to_servfail();
 
@@ -814,82 +659,17 @@ after_recv(
   );
 }
 
-// Handle a resolve result and respond to a DNS query for the recursive
-// resolver - called on the libunbound worker thread
 static void
-after_resolve_onthread(void *data, int status, struct ub_result *result) {
+after_resolve(void *data, int status, struct ub_result *result) {
   hsk_dns_req_t *req = (hsk_dns_req_t *)data;
-  // We can safely get the nameserver object from the request; the main thread
-  // does not use it after ub_resolve_async() succeeds (ownership is passed to
-  // this callback).
   hsk_rs_t *ns = (hsk_rs_t *)req->ns;
 
-  hsk_rs_rsp_t *rsp = malloc(sizeof(hsk_rs_rsp_t));
-  if(!rsp)
-    return;
+  assert(ns);
 
-  rsp->next = NULL;
-  rsp->req = req;
-  rsp->result = result;
-  rsp->status = status;
-
-  // Enqueue the response.  This is safe to do on the worker thread:
-  // - The ns->rs_queue pointer is not modified after initialization until the
-  //   worker thread has been stopped
-  // - The hsk_rs_queue_t object itself is thread-safe
-  hsk_rs_queue_enqueue(ns->rs_queue, rsp);
-
-  // Queue an async event to process the response on the libuv event loop.
-  // Like rs_queue, the rs_async pointer is safe to use because it's not
-  // modified until the libunbound worker is stopped.
-  uv_async_send(ns->rs_async);
-}
-
-static void
-after_resolve(uv_async_t *async) {
-  hsk_rs_t *ns = (hsk_rs_t *)async->data;
-
-  // Since uv_close() is async, it might be possible to process this event after
-  // the NS is shut down but before the async is closed.
-  if(!ns)
-    return;
-
-  // Dequeue and process all events in the queue - libuv coalesces calls to
-  // uv_async_send().
-  hsk_rs_rsp_t *rsp = hsk_rs_queue_dequeue(ns->rs_queue);
-  while(rsp) {
-    hsk_rs_respond(ns, rsp->req, rsp->status, rsp->result);
-
-    hsk_dns_req_free(rsp->req);
-    ub_resolve_free(rsp->result);
-    free(rsp);
-
-    rsp = hsk_rs_queue_dequeue(ns->rs_queue);
-  }
+  hsk_rs_respond(ns, req, status, result);
+  hsk_dns_req_free(req);
+  ub_resolve_free(result);
 }
 
 static void
 after_close(uv_handle_t *handle) {}
-
-static void
-after_close_free(uv_handle_t *handle) {
-  free(handle);
-}
-
-static void
-run_unbound_worker(void *arg) {
-  hsk_rs_t *ns = (hsk_rs_t *)arg;
-
-  while(ns->rs_worker_running) {
-    ub_wait(ns->ub);
-  }
-}
-
-static void
-after_resolve_shutdown(void *data, int status, struct ub_result *result) {
-  ub_resolve_free(result);
-
-  hsk_rs_t *ns = (hsk_rs_t *)data;
-
-  ns->rs_worker_running = false;
-}

--- a/src/rs.c
+++ b/src/rs.c
@@ -679,7 +679,11 @@ after_resolve(void *data, int status, struct ub_result *result) {
 
   assert(ns);
 
-  hsk_rs_respond(ns, req, status, result);
+  // If the request is aborted, result is NULL, we just need to free req in that
+  // case
+  if (result) {
+    hsk_rs_respond(ns, req, status, result);
+    ub_resolve_free(result);
+  }
   hsk_dns_req_free(req);
-  ub_resolve_free(result);
 }

--- a/src/rs.c
+++ b/src/rs.c
@@ -64,14 +64,113 @@ after_recv(
   unsigned flags
 );
 
+// Resolve callback on libunbound worker thread.
 static void
-after_poll(uv_poll_t *handle, int status, int events);
+after_resolve_onthread(void *data, int status, struct ub_result *result);
 
+// Resolve async event handler in libuv event loop.
 static void
-after_resolve(void *data, int status, struct ub_result *result);
+after_resolve(uv_async_t *async);
 
 static void
 after_close(uv_handle_t *handle);
+
+static void
+after_close_free(uv_handle_t *handle);
+
+static void
+run_unbound_worker(void *arg);
+
+static void
+after_resolve_shutdown(void *data, int status, struct ub_result *result);
+
+/*
+ * Response Queue
+ */
+int
+hsk_rs_queue_init(hsk_rs_queue_t *queue) {
+  if (uv_mutex_init(&queue->mutex))
+    return HSK_EFAILURE;
+  queue->head = NULL;
+  queue->tail = NULL;
+
+  return HSK_SUCCESS;
+}
+
+void
+hsk_rs_queue_uninit(hsk_rs_queue_t *queue) {
+  hsk_rs_rsp_t *current = queue->head;
+  while (current) {
+    hsk_rs_rsp_t *next = current->next;
+    free(current);
+    current = next;
+  }
+
+  uv_mutex_destroy(&queue->mutex);
+}
+
+hsk_rs_queue_t *hsk_rs_queue_alloc() {
+  hsk_rs_queue_t *queue = malloc(sizeof(hsk_rs_queue_t));
+  if(!queue)
+    return NULL;
+
+  if (hsk_rs_queue_init(queue) != HSK_SUCCESS) {
+    free(queue);
+    return NULL;
+  }
+
+  return queue;
+}
+
+void hsk_rs_queue_free(hsk_rs_queue_t *queue) {
+  if(!queue)
+    return;
+
+  hsk_rs_queue_uninit(queue);
+  free(queue);
+}
+
+// Dequeue the oldest queued response - thread-safe.
+// Returned object is now owned by the caller; returns nullptr if there is
+// nothing queued.
+hsk_rs_rsp_t *
+hsk_rs_queue_dequeue(hsk_rs_queue_t *queue) {
+  uv_mutex_lock(&queue->mutex);
+
+  hsk_rs_rsp_t *oldest = queue->head;
+  if (oldest) {
+    queue->head = oldest->next;
+    oldest->next = NULL;
+    // If this was the only queued request, clear tail too
+    if(queue->tail == oldest)
+      queue->tail = NULL;
+  }
+
+  uv_mutex_unlock(&queue->mutex);
+
+  return oldest;
+}
+
+// Enqueue a response - thread-safe.
+// The queue takes ownership of the response (until it's popped off again).
+void
+hsk_rs_queue_enqueue(hsk_rs_queue_t *queue, hsk_rs_rsp_t *rsp) {
+  uv_mutex_lock(&queue->mutex);
+
+  if (!queue->tail) {
+    // There were no requests queued; this one becomes head and tail
+    assert(!queue->head);   // Invariant - set and cleared together
+    queue->head = rsp;
+    queue->tail = rsp;
+  }
+  else {
+    // There are requests queued already, add this one to the tail
+    queue->tail->next = rsp;
+    queue->tail = rsp;
+  }
+
+  uv_mutex_unlock(&queue->mutex);
+}
 
 /*
  * Recursive NS
@@ -85,6 +184,8 @@ hsk_rs_init(hsk_rs_t *ns, const uv_loop_t *loop, const struct sockaddr *stub) {
   int err = HSK_ENOMEM;
   struct ub_ctx *ub = NULL;
   hsk_ec_t *ec = NULL;
+  hsk_rs_queue_t *rs_queue = NULL;
+  uv_async_t *rs_async = NULL;
 
   ub = ub_ctx_create();
 
@@ -92,6 +193,16 @@ hsk_rs_init(hsk_rs_t *ns, const uv_loop_t *loop, const struct sockaddr *stub) {
     goto fail;
 
   if (ub_ctx_async(ub, 1) != 0)
+    goto fail;
+
+  rs_queue = hsk_rs_queue_alloc();
+
+  if (!rs_queue)
+    goto fail;
+
+  // Allocate this separately on the heap because uv_close() is asynchronous.
+  rs_async = malloc(sizeof(uv_async_t));
+  if (!rs_async || uv_async_init((uv_loop_t*)loop, rs_async, after_resolve))
     goto fail;
 
   ec = hsk_ec_alloc();
@@ -102,7 +213,9 @@ hsk_rs_init(hsk_rs_t *ns, const uv_loop_t *loop, const struct sockaddr *stub) {
   ns->loop = (uv_loop_t *)loop;
   ns->ub = ub;
   ns->socket.data = (void *)ns;
-  ns->poll.data = (void *)ns;
+  ns->rs_queue = rs_queue;
+  ns->rs_async = rs_async;
+  ns->rs_async->data = (void *)ns;
   ns->ec = ec;
   ns->config = NULL;
   ns->stub = (struct sockaddr *)&ns->stub_;
@@ -113,7 +226,7 @@ hsk_rs_init(hsk_rs_t *ns, const uv_loop_t *loop, const struct sockaddr *stub) {
   memset(ns->read_buffer, 0x00, sizeof(ns->read_buffer));
   ns->bound = false;
   ns->receiving = false;
-  ns->polling = false;
+  ns->rs_worker_running = false;
 
   if (stub) {
     err = HSK_EFAILURE;
@@ -131,6 +244,12 @@ fail:
   if (ub)
     ub_ctx_delete(ub);
 
+  if (rs_queue)
+    hsk_rs_queue_free(rs_queue);
+
+  if (rs_async)
+    free(rs_async);
+
   if (ec)
     hsk_ec_free(ec);
 
@@ -143,7 +262,6 @@ hsk_rs_uninit(hsk_rs_t *ns) {
     return;
 
   ns->socket.data = NULL;
-  ns->poll.data = NULL;
 
   if (ns->ec) {
     hsk_ec_free(ns->ec);
@@ -153,6 +271,21 @@ hsk_rs_uninit(hsk_rs_t *ns) {
   if (ns->ub) {
     ub_ctx_delete(ns->ub);
     ns->ub = NULL;
+  }
+
+  // Free the response event and queue after destroying the unbound context.
+  // The libunbound worker has now stopped, so we can safely free these.
+  if (ns->rs_async) {
+    ns->rs_async->data = NULL;
+    // We have to free this object in the callback, libuv specifically says it
+    // must not be freed before the callback occurs
+    uv_close((uv_handle_t *)ns->rs_async, after_close_free);
+    ns->rs_async = NULL;
+  }
+
+  if (ns->rs_queue) {
+    hsk_rs_queue_free(ns->rs_queue);
+    ns->rs_queue = NULL;
   }
 
   if (ns->config) {
@@ -246,6 +379,10 @@ hsk_rs_inject_options(hsk_rs_t *ns) {
     return false;
   }
 
+  // Use a thread instead of forking for libunbound's async work.  Threads work
+  // on all platforms, but forking does not work on Windows.
+  ub_ctx_async(ns->ub, 1);
+
   hsk_rs_log(ns, "recursive nameserver pointing to: %s\n", stub);
 
   return true;
@@ -282,14 +419,11 @@ hsk_rs_open(hsk_rs_t *ns, const struct sockaddr *addr) {
 
   ns->receiving = true;
 
-  if (uv_poll_init(ns->loop, &ns->poll, ub_fd(ns->ub)) != 0)
+  ns->rs_worker_running = true;
+  if (uv_thread_create(&ns->rs_worker, run_unbound_worker, (void *)ns) != 0) {
+    ns->rs_worker_running = false;
     return HSK_EFAILURE;
-
-  ns->polling = true;
-  ns->poll.data = (void *)ns;
-
-  if (uv_poll_start(&ns->poll, UV_READABLE, after_poll) != 0)
-    return HSK_EFAILURE;
+  }
 
   char host[HSK_MAX_HOST];
   assert(hsk_sa_to_string(addr, host, HSK_MAX_HOST, HSK_NS_PORT));
@@ -304,6 +438,25 @@ hsk_rs_close(hsk_rs_t *ns) {
   if (!ns)
     return HSK_EBADARGS;
 
+  if (ns->rs_worker_running) {
+    // We need to tell the libunbound worker to exit - wake up the thread and
+    // clear rs_worker_running on that thread.
+    //
+    // libunbound doesn't give us a good way to do this, the only way is to
+    // issue a dummy query and do this in the callback on the worker thread.
+    //
+    // On Unix, we could poll unbound's file descriptor manually with another
+    // file descriptor to allow us to wake the thread here.  On Windows though,
+    // libunbound does not provide any access to its WSAEVENT to do the same
+    // thing.
+    int rc = ub_resolve_async(ns->ub, ".", HSK_DNS_NS, HSK_DNS_IN, (void *)ns,
+                              after_resolve_shutdown, NULL);
+    if(rc != 0)
+      hsk_rs_log(ns, "cannot shut down worker thread: %s\n", ub_strerror(rc));
+    else
+      uv_thread_join(&ns->rs_worker);
+  }
+
   if (ns->receiving) {
     if (uv_udp_recv_stop(&ns->socket) != 0)
       return HSK_EFAILURE;
@@ -315,14 +468,7 @@ hsk_rs_close(hsk_rs_t *ns) {
     ns->bound = false;
   }
 
-  if (ns->polling) {
-    if (uv_poll_stop(&ns->poll) != 0)
-      return HSK_EFAILURE;
-    ns->polling = false;
-  }
-
   ns->socket.data = NULL;
-  ns->poll.data = NULL;
 
   if (ns->ub) {
     ub_ctx_delete(ns->ub);
@@ -416,7 +562,7 @@ hsk_rs_onrecv(
     req->type,
     req->class,
     (void *)req,
-    after_resolve,
+    after_resolve_onthread,
     NULL
   );
 
@@ -668,28 +814,82 @@ after_recv(
   );
 }
 
+// Handle a resolve result and respond to a DNS query for the recursive
+// resolver - called on the libunbound worker thread
 static void
-after_poll(uv_poll_t *handle, int status, int events) {
-  hsk_rs_t *ns = (hsk_rs_t *)handle->data;
+after_resolve_onthread(void *data, int status, struct ub_result *result) {
+  hsk_dns_req_t *req = (hsk_dns_req_t *)data;
+  // We can safely get the nameserver object from the request; the main thread
+  // does not use it after ub_resolve_async() succeeds (ownership is passed to
+  // this callback).
+  hsk_rs_t *ns = (hsk_rs_t *)req->ns;
 
-  if (!ns)
+  hsk_rs_rsp_t *rsp = malloc(sizeof(hsk_rs_rsp_t));
+  if(!rsp)
     return;
 
-  if (status == 0 && (events & UV_READABLE))
-    ub_process(ns->ub);
+  rsp->next = NULL;
+  rsp->req = req;
+  rsp->result = result;
+  rsp->status = status;
+
+  // Enqueue the response.  This is safe to do on the worker thread:
+  // - The ns->rs_queue pointer is not modified after initialization until the
+  //   worker thread has been stopped
+  // - The hsk_rs_queue_t object itself is thread-safe
+  hsk_rs_queue_enqueue(ns->rs_queue, rsp);
+
+  // Queue an async event to process the response on the libuv event loop.
+  // Like rs_queue, the rs_async pointer is safe to use because it's not
+  // modified until the libunbound worker is stopped.
+  uv_async_send(ns->rs_async);
 }
 
 static void
-after_resolve(void *data, int status, struct ub_result *result) {
-  hsk_dns_req_t *req = (hsk_dns_req_t *)data;
-  hsk_rs_t *ns = (hsk_rs_t *)req->ns;
+after_resolve(uv_async_t *async) {
+  hsk_rs_t *ns = (hsk_rs_t *)async->data;
 
-  assert(ns);
+  // Since uv_close() is async, it might be possible to process this event after
+  // the NS is shut down but before the async is closed.
+  if(!ns)
+    return;
 
-  hsk_rs_respond(ns, req, status, result);
-  hsk_dns_req_free(req);
-  ub_resolve_free(result);
+  // Dequeue and process all events in the queue - libuv coalesces calls to
+  // uv_async_send().
+  hsk_rs_rsp_t *rsp = hsk_rs_queue_dequeue(ns->rs_queue);
+  while(rsp) {
+    hsk_rs_respond(ns, rsp->req, rsp->status, rsp->result);
+
+    hsk_dns_req_free(rsp->req);
+    ub_resolve_free(rsp->result);
+    free(rsp);
+
+    rsp = hsk_rs_queue_dequeue(ns->rs_queue);
+  }
 }
 
 static void
 after_close(uv_handle_t *handle) {}
+
+static void
+after_close_free(uv_handle_t *handle) {
+  free(handle);
+}
+
+static void
+run_unbound_worker(void *arg) {
+  hsk_rs_t *ns = (hsk_rs_t *)arg;
+
+  while(ns->rs_worker_running) {
+    ub_wait(ns->ub);
+  }
+}
+
+static void
+after_resolve_shutdown(void *data, int status, struct ub_result *result) {
+  ub_resolve_free(result);
+
+  hsk_rs_t *ns = (hsk_rs_t *)data;
+
+  ns->rs_worker_running = false;
+}

--- a/src/rs.h
+++ b/src/rs.h
@@ -30,6 +30,8 @@ typedef struct {
   uint8_t read_buffer[4096];
   bool bound;
   bool receiving;
+  void *stop_data;
+  void (*stop_callback)(void *);
 } hsk_rs_t;
 
 /*
@@ -51,15 +53,14 @@ hsk_rs_set_key(hsk_rs_t *ns, const uint8_t *key);
 int
 hsk_rs_open(hsk_rs_t *ns, const struct sockaddr *addr);
 
+// Close the recursive name server.  This may complete asynchronously;
+// stop_callback is called when the name server can be destroyed.
 int
-hsk_rs_close(hsk_rs_t *ns);
+hsk_rs_close(hsk_rs_t *ns, void *stop_data, void (*stop_callback)(void *));
 
 hsk_rs_t *
 hsk_rs_alloc(const uv_loop_t *loop, const struct sockaddr *stub);
 
 void
 hsk_rs_free(hsk_rs_t *ns);
-
-int
-hsk_rs_destroy(hsk_rs_t *ns);
 #endif

--- a/src/rs.h
+++ b/src/rs.h
@@ -18,7 +18,7 @@
 typedef struct {
   uv_loop_t *loop;
   struct ub_ctx *ub;
-  uv_udp_t socket;
+  uv_udp_t *socket;
   hsk_rs_worker_t *rs_worker;
   hsk_ec_t *ec;
   char *config;
@@ -28,7 +28,6 @@ typedef struct {
   uint8_t *key;
   uint8_t pubkey[33];
   uint8_t read_buffer[4096];
-  bool bound;
   bool receiving;
   void *stop_data;
   void (*stop_callback)(void *);

--- a/src/rs.h
+++ b/src/rs.h
@@ -8,34 +8,18 @@
 #include <unbound.h>
 
 #include "ec.h"
+#include "rs_worker.h"
 #include "uv.h"
 
 /*
  * Types
  */
 
-// Response data from libunbound - used to queue responses back to the libuv
-// event loop in a linked list
-typedef struct _hsk_rs_rsp_t {
-  struct _hsk_rs_rsp_t *next;
-  hsk_dns_req_t *req;
-  struct ub_result *result;
-  int status;
-} hsk_rs_rsp_t;
-
-typedef struct {
-  uv_mutex_t mutex;
-  hsk_rs_rsp_t *head;  // Oldest response
-  hsk_rs_rsp_t *tail;  // Newest response
-} hsk_rs_queue_t;
-
 typedef struct {
   uv_loop_t *loop;
   struct ub_ctx *ub;
   uv_udp_t socket;
-  hsk_rs_queue_t *rs_queue;
-  uv_async_t *rs_async;
-  uv_thread_t rs_worker;
+  hsk_rs_worker_t *rs_worker;
   hsk_ec_t *ec;
   char *config;
   struct sockaddr_storage stub_;
@@ -46,7 +30,6 @@ typedef struct {
   uint8_t read_buffer[4096];
   bool bound;
   bool receiving;
-  bool rs_worker_running;
 } hsk_rs_t;
 
 /*

--- a/src/rs_worker.c
+++ b/src/rs_worker.c
@@ -1,6 +1,7 @@
 #include "config.h"
 
 #include <assert.h>
+#include <stdarg.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <unbound.h>
@@ -8,6 +9,7 @@
 #include "dns.h"
 #include "error.h"
 #include "rs_worker.h"
+#include "utils.h"
 #include "uv.h"
 
 /*
@@ -16,8 +18,11 @@
 static void
 hsk_rs_worker_log(hsk_rs_worker_t *ns, const char *fmt, ...);
 
+static uv_async_t *
+alloc_async(hsk_rs_worker_t *worker, uv_loop_t *loop, uv_async_cb callback);
+
 static void
-after_close_free(uv_handle_t *handle);
+free_async(uv_async_t *async);
 
 static void
 run_unbound_worker(void *arg);
@@ -30,6 +35,9 @@ after_resolve_onthread(void *data, int status, struct ub_result *result);
 
 static void
 after_resolve_async(uv_async_t *async);
+
+static void
+after_quit_async(uv_async_t *async);
 
 /*
  * Response Queue
@@ -124,13 +132,17 @@ hsk_rs_queue_enqueue(hsk_rs_queue_t *queue, hsk_rs_rsp_t *rsp) {
  * Response worker thread
  */
 int
-hsk_rs_worker_init(hsk_rs_worker_t *worker, uv_loop_t *loop, struct ub_ctx *ub) {
-  if (!worker || !loop || !ub)
+hsk_rs_worker_init(hsk_rs_worker_t *worker, uv_loop_t *loop, void *stop_data,
+                   void (*stop_callback)(void *)) {
+  if (!worker || !loop || !stop_callback)
     return HSK_EBADARGS;
 
   worker->rs_queue = NULL;
   worker->rs_async = NULL;
   worker->ub = NULL;
+  worker->cb_stop_data = stop_data;
+  worker->cb_stop_func = stop_callback;
+  worker->closing = false;
 
   worker->rs_queue = hsk_rs_queue_alloc();
   if (!worker->rs_queue) {
@@ -138,32 +150,13 @@ hsk_rs_worker_init(hsk_rs_worker_t *worker, uv_loop_t *loop, struct ub_ctx *ub) 
     goto fail;
   }
 
-  // Allocate this separately on the heap because uv_close() is asynchronous.
-  worker->rs_async = malloc(sizeof(uv_async_t));
-  if (!worker->rs_async) {
-    hsk_rs_worker_log(worker, "out of memory");
+  worker->rs_async = alloc_async(worker, loop, after_resolve_async);
+  if (!worker->rs_async)
     goto fail;
-  }
 
-  // Initialize the async and set data if successful.  (This also indicates to
-  // the cleanup logic that the async needs to be closed.)
-  worker->rs_async->data = NULL;
-  if (uv_async_init(loop, worker->rs_async, after_resolve_async)) {
-    hsk_rs_worker_log(worker, "failed to create libuv async event");
+  worker->rs_quit_async = alloc_async(worker, loop, after_quit_async);
+  if (!worker->rs_quit_async)
     goto fail;
-  }
-  worker->rs_async->data = (void *)worker;
-
-  // Start the worker thread.  Set unbound context to indicate that the thread
-  // is running.  If it starts, we can no longer write worker->ub until we sync
-  // up both threads again in _uninit().
-  worker->ub = ub;
-  if (uv_thread_create(&worker->rs_thread, run_unbound_worker, (void *)worker)) {
-    hsk_rs_worker_log(worker, "failed to create libuv worker thread");
-    // Failed to start, not running.
-    worker->ub = NULL;
-    goto fail;
-  }
 
   return HSK_SUCCESS;
 
@@ -178,38 +171,15 @@ hsk_rs_worker_uninit(hsk_rs_worker_t *worker) {
   // Note that _uninit() is also used to clean up a partially-constructed
   // worker if _init() fails.
 
-  if (worker->ub) {
-    // We need to tell the libunbound worker to exit - wake up the thread and
-    // clear ub on that thread.
-    //
-    // libunbound doesn't give us a good way to do this, the only way is to
-    // issue a dummy query and do this in the callback on the worker thread.
-    //
-    // On Unix, we could poll unbound's file descriptor manually with another
-    // file descriptor to allow us to wake the thread another way.  On Windows
-    // though, libunbound does not provide any access to its WSAEVENT to do the
-    // same thing; there's no other way to do this.
-    int rc = ub_resolve_async(worker->ub, ".", HSK_DNS_NS, HSK_DNS_IN,
-                              (void *)worker, after_resolve_shutdown, NULL);
-    if (rc != 0)
-      hsk_rs_worker_log(worker, "cannot shut down worker thread: %s\n", ub_strerror(rc));
-    else
-      uv_thread_join(&worker->rs_thread);
-  }
+  // Can't destroy while still closing.
+  assert(!worker->closing);
 
-  if (worker->rs_async) {
-    // If it was also initialized, close it and free asynchronously
-    if (worker->rs_async->data) {
-      worker->rs_async->data = NULL;
-      uv_close((uv_handle_t *)worker->rs_async, after_close_free);
-      worker->rs_async = NULL;
-    }
-    else {
-      // Wasn't initialized, just free memory
-      free(worker->rs_async);
-      worker->rs_async = NULL;
-    }
-  }
+  // Can't destroy while worker is still running.
+  assert(!worker->ub);
+
+  free_async(worker->rs_quit_async);
+
+  free_async(worker->rs_async);
 
   if (worker->rs_queue) {
     hsk_rs_queue_free(worker->rs_queue);
@@ -217,13 +187,76 @@ hsk_rs_worker_uninit(hsk_rs_worker_t *worker) {
   }
 }
 
+int
+hsk_rs_worker_open(hsk_rs_worker_t *worker, struct ub_ctx *ub) {
+  // Can't open if closing or already open.
+  assert(!worker->closing);
+  assert(!worker->ub);
+
+  // Start the worker thread.  Set unbound context to indicate that the thread
+  // is running.  If it starts, we can no longer write worker->ub from this
+  // thread.
+  worker->ub = ub;
+  if (uv_thread_create(&worker->rs_thread, run_unbound_worker, (void *)worker)) {
+    hsk_rs_worker_log(worker, "failed to create libuv worker thread");
+    // Failed to start, not running.
+    worker->ub = NULL;
+    return HSK_EFAILURE;
+  }
+
+  return HSK_SUCCESS;
+}
+
+bool
+hsk_rs_worker_is_open(hsk_rs_worker_t *worker) {
+  // If we're closing, the worker is open, don't read ub.  Otherwise, we're open
+  // if ub is set.
+  return !worker->closing || worker->ub;
+}
+
+void
+hsk_rs_worker_close(hsk_rs_worker_t *worker) {
+  // No effect if already closing
+  if (worker->closing)
+    return;
+
+  // Must be open
+  assert(worker->ub);
+
+  // Can't read worker->ub any more from the main thread once we tell the thread
+  // to close.
+  worker->closing = true;
+
+  // We need to tell the libunbound worker to exit - wake up the thread and
+  // clear ub on that thread.
+  //
+  // libunbound doesn't give us a good way to do this, the only way is to
+  // issue a dummy query and do this in the callback on the worker thread.
+  //
+  // This works whether the request is successful or not.  As long as the
+  // authoritative server initialized, it'll complete quickly (even if it could
+  // not reach any peers).  If the authoritative server did not initialize, it
+  // will unfortunately wait for a timeout.
+  //
+  // On Unix, we could poll unbound's file descriptor manually with another
+  // file descriptor to allow us to wake the thread another way.  On Windows
+  // though, libunbound does not provide any access to its WSAEVENT to do the
+  // same thing; there's no other way to do this.
+  hsk_rs_worker_log(worker, "stopping libunbound worker...\n");
+  int rc = ub_resolve_async(worker->ub, ".", HSK_DNS_NS, HSK_DNS_IN,
+                            (void *)worker, after_resolve_shutdown, NULL);
+  if (rc != 0)
+    hsk_rs_worker_log(worker, "cannot stop worker thread: %s\n", ub_strerror(rc));
+}
+
 hsk_rs_worker_t *
-hsk_rs_worker_alloc(uv_loop_t *loop, struct ub_ctx *ub) {
+hsk_rs_worker_alloc(uv_loop_t *loop, void *stop_data,
+                    void (*stop_callback)(void *)) {
   hsk_rs_worker_t *worker = malloc(sizeof(hsk_rs_worker_t));
   if (!worker)
     return NULL;
 
-  if (hsk_rs_worker_init(worker, loop, ub) != HSK_SUCCESS) {
+  if (hsk_rs_worker_init(worker, loop, stop_data, stop_callback) != HSK_SUCCESS) {
     free(worker);
     return NULL;
   }
@@ -244,6 +277,10 @@ hsk_rs_worker_resolve(hsk_rs_worker_t *worker, char *name, int rrtype,
                       int rrclass, void *data, ub_callback_type callback) {
   if (!callback)
     return HSK_EBADARGS;
+
+  // Can't resolve when closing or not open
+  if (worker->closing || !worker->ub)
+    return HSK_EFAILURE;
 
   // Hold the callback data/func in a response object.  When the results come
   // in, we'll fill in the rest of this object and add it to the result queue.
@@ -274,9 +311,33 @@ hsk_rs_worker_log(hsk_rs_worker_t *worker, const char *fmt, ...) {
   va_end(args);
 }
 
+static uv_async_t *
+alloc_async(hsk_rs_worker_t *worker, uv_loop_t *loop, uv_async_cb callback) {
+  uv_async_t *async = malloc(sizeof(uv_async_t));
+  if (!async) {
+    hsk_rs_worker_log(worker, "out of memory");
+    return NULL;
+  }
+  async->data = NULL;
+
+  // Initialize the async
+  if (uv_async_init(loop, async, callback)) {
+    hsk_rs_worker_log(worker, "failed to create libuv async event");
+    free(async);
+    return NULL;
+  }
+
+  async->data = (void *)worker;
+
+  return async;
+}
+
 static void
-after_close_free(uv_handle_t *handle) {
-  free(handle);
+free_async(uv_async_t *async) {
+  if(async) {
+    async->data = NULL;
+    hsk_uv_close_free((uv_handle_t *)async);
+  }
 }
 
 static void
@@ -286,6 +347,8 @@ run_unbound_worker(void *arg) {
   while(worker->ub) {
     ub_wait(worker->ub);
   }
+
+  uv_async_send(worker->rs_quit_async);
 }
 
 static void
@@ -296,8 +359,9 @@ after_resolve_shutdown(void *data, int status, struct ub_result *result) {
 
   // Clear this to stop the worker event loop.  This is safe because we've
   // synced up both threads to ensure they're not reading this - the main thread
-  // won't read it any more at all (it's just going to wait for the worker to
-  // exit with a _join()), and we're inside a ub_wait() on the worker thread.
+  // won't read it any more at all (it's waiting for the worker thread to exit
+  // after _close() was called), and we're inside a ub_wait() on the worker
+  // thread.
   worker->ub = NULL;
 }
 
@@ -325,10 +389,10 @@ after_resolve_onthread(void *data, int status, struct ub_result *result) {
 
 static void
 after_resolve_async(uv_async_t *async) {
-  hsk_rs_worker_t *worker = async->data;
+  hsk_rs_worker_t *worker = (hsk_rs_worker_t *)async->data;
 
   // Since uv_close() is async, it might be possible to process this event after
-  // the worker is shut down but before the async is closed.
+  // the worker is destroyed but before the async is closed.
   if(!worker)
     return;
 
@@ -344,4 +408,20 @@ after_resolve_async(uv_async_t *async) {
 
     rsp = hsk_rs_queue_dequeue(worker->rs_queue);
   }
+}
+
+static void
+after_quit_async(uv_async_t *async) {
+  hsk_rs_worker_t *worker = (hsk_rs_worker_t *)async->data;
+
+  // Should never get this after worker is destroyed, the worker can't be
+  // destroyed until _close() completes.
+  assert(worker);
+
+  worker->closing = false;
+
+  hsk_rs_worker_log(worker, "libunbound worker stopped\n");
+
+  // worker may be freed by this callback.
+  worker->cb_stop_func(worker->cb_stop_data);
 }

--- a/src/rs_worker.c
+++ b/src/rs_worker.c
@@ -16,6 +16,9 @@
  * Prototypes
  */
 static void
+hsk_rs_pending_log(hsk_rs_pending_t *pending, const char *fmt, ...);
+
+static void
 hsk_rs_worker_log(hsk_rs_worker_t *ns, const char *fmt, ...);
 
 static uv_async_t *
@@ -26,9 +29,6 @@ free_async(uv_async_t *async);
 
 static void
 run_unbound_worker(void *arg);
-
-static void
-after_resolve_shutdown(void *data, int status, struct ub_result *result);
 
 static void
 after_resolve_onthread(void *data, int status, struct ub_result *result);
@@ -57,6 +57,11 @@ hsk_rs_queue_uninit(hsk_rs_queue_t *queue) {
   hsk_rs_rsp_t *current = queue->head;
   while (current) {
     hsk_rs_rsp_t *next = current->next;
+
+    // For responses still in the queue, call them now to ensure they don't
+    // leak memory
+    current->cb_func(current->cb_data, current->status, current->result);
+
     free(current);
     current = next;
   }
@@ -97,9 +102,12 @@ hsk_rs_queue_dequeue(hsk_rs_queue_t *queue) {
   if (oldest) {
     queue->head = oldest->next;
     oldest->next = NULL;
-    // If this was the only queued request, clear tail too
-    if(queue->tail == oldest)
+    if(queue->head)
+      queue->head->prev = NULL; // Removed the prior request
+    else {
+      assert(queue->tail == oldest); // There was only one request
       queue->tail = NULL;
+    }
   }
 
   uv_mutex_unlock(&queue->mutex);
@@ -122,10 +130,179 @@ hsk_rs_queue_enqueue(hsk_rs_queue_t *queue, hsk_rs_rsp_t *rsp) {
   else {
     // There are requests queued already, add this one to the tail
     queue->tail->next = rsp;
+    rsp->prev = queue->tail;
     queue->tail = rsp;
   }
 
   uv_mutex_unlock(&queue->mutex);
+}
+
+/*
+ * Pending Requests
+ */
+int
+hsk_rs_pending_init(hsk_rs_pending_t *pending) {
+  if (uv_mutex_init(&pending->mutex))
+    return HSK_EFAILURE;
+  if (uv_cond_init(&pending->cond)) {
+    uv_mutex_destroy(&pending->mutex);
+    return HSK_EFAILURE;
+  }
+  pending->head = NULL;
+  pending->tail = NULL;
+  pending->exit = false;
+
+  return HSK_SUCCESS;
+}
+
+void
+hsk_rs_pending_uninit(hsk_rs_pending_t *pending) {
+  // There shouldn't be any outstanding requests, they would have been discarded
+  // by _reset()
+  assert(!pending->head);
+
+  uv_cond_destroy(&pending->cond);
+  uv_mutex_destroy(&pending->mutex);
+}
+
+hsk_rs_pending_t *
+hsk_rs_pending_alloc() {
+  hsk_rs_pending_t *pending = malloc(sizeof(hsk_rs_pending_t));
+  if (!pending)
+    return NULL;
+
+  if (hsk_rs_pending_init(pending) != HSK_SUCCESS) {
+    free(pending);
+    return NULL;
+  }
+
+  return pending;
+}
+
+void
+hsk_rs_pending_free(hsk_rs_pending_t *pending) {
+  if(pending) {
+    hsk_rs_pending_uninit(pending);
+    free(pending);
+  }
+}
+
+// Enqueue a pending request
+void
+hsk_rs_pending_enqueue(hsk_rs_pending_t *pending, hsk_rs_rsp_t *rsp) {
+  uv_mutex_lock(&pending->mutex);
+
+  if (!pending->tail) {
+    assert(!pending->head);   // Invariant - set and cleared together
+    pending->head = rsp;
+    pending->tail = rsp;
+  }
+  else {
+    pending->tail->next = rsp;
+    rsp->prev = pending->tail;
+    pending->tail = rsp;
+  }
+
+  uv_cond_signal(&pending->cond);
+  uv_mutex_unlock(&pending->mutex);
+}
+
+// Remove a request that has received a response
+void
+hsk_rs_pending_remove(hsk_rs_pending_t *pending, hsk_rs_rsp_t *rsp) {
+  uv_mutex_lock(&pending->mutex);
+
+  // rsp must be in this queue, which means we must have at least one request
+  // (rsp->prev and rsp->next could be NULL though if it is the only request)
+  assert(pending->head);
+  assert(pending->tail);
+
+  if(rsp->prev) {
+    rsp->prev->next = rsp->next;
+  }
+  else {
+    assert(pending->head == rsp);   // head of list
+    pending->head = rsp->next;  // NULL if this is the only request
+  }
+
+  if(rsp->next) {
+    rsp->next->prev = rsp->prev;
+  }
+  else {
+    assert(pending->tail == rsp);   // tail of list
+    pending->tail = rsp->prev;
+  }
+
+  rsp->next = rsp->prev = NULL;
+
+  uv_mutex_unlock(&pending->mutex);
+}
+
+// Signal the worker thread to exit.  Cancels all outstanding requests to
+// libunbound.
+void
+hsk_rs_pending_exit(hsk_rs_pending_t *pending) {
+  uv_mutex_lock(&pending->mutex);
+  pending->exit = true;
+
+  // The worker thread won't be able to exit until ub_wait() returns, which is
+  // after all outstanding requests are resolved.  In the worst case, this could
+  // take a few minutes to time out if nameservers are not responding (this is
+  // not configurable in libunbound).
+  //
+  // We _could_ attempt to cancel the outstanding requests here, but then
+  // ub_wait() seens to _never_ return, even if we issue another request to try
+  // to kick it out of its wait.  libunbound might be leaking request counts
+  // after cancelling a request.  Instead, just trace the outstanding requests.
+  for(hsk_rs_rsp_t *current = pending->head; current; current = current->next) {
+    hsk_rs_pending_log(pending, "still pending: %d\n", current->async_id);
+  }
+
+  uv_cond_signal(&pending->cond);
+  uv_mutex_unlock(&pending->mutex);
+}
+
+// Check whether worker has been signaled to exit (including if it has exited)
+bool
+hsk_rs_pending_exiting(hsk_rs_pending_t *pending) {
+  uv_mutex_lock(&pending->mutex);
+  bool ret = pending->exit;
+  uv_mutex_unlock(&pending->mutex);
+  return ret;
+}
+
+// Reset after the worker thread has returned - clears exit flag and discards
+// any remaining requests
+void
+hsk_rs_pending_reset(hsk_rs_pending_t *pending) {
+  uv_mutex_lock(&pending->mutex);
+  pending->exit = false;
+
+  // There shouldn't be anything left at this point; _wait() does not indicate
+  // to exit until there are no requests left _and_ exit is signaled.
+  assert(!pending->head);
+  assert(!pending->tail);
+
+  uv_mutex_unlock(&pending->mutex);
+}
+
+// Wait until there is a pending request (returns true) or worker is signaled to exit
+// (returns false)
+bool
+hsk_rs_pending_wait(hsk_rs_pending_t *pending) {
+  uv_mutex_lock(&pending->mutex);
+  while(!pending->head && !pending->exit) {
+    // Wait until cond is signaled (count is incremented or thread is told to
+    // exit)
+    uv_cond_wait(&pending->cond, &pending->mutex);
+  }
+  // Return 'true' (process requests) if there is at least one outstanding
+  // request, even if we are also signaled to exit.  We can't exit if a request
+  // couldn't be canceled but hasn't been delivered yet; we would leak the
+  // response object.
+  bool ret = pending->head;
+  uv_mutex_unlock(&pending->mutex);
+  return ret;
 }
 
 /*
@@ -138,15 +315,21 @@ hsk_rs_worker_init(hsk_rs_worker_t *worker, uv_loop_t *loop, void *stop_data,
     return HSK_EBADARGS;
 
   worker->rs_queue = NULL;
+  worker->rs_pending = NULL;
   worker->rs_async = NULL;
   worker->ub = NULL;
   worker->cb_stop_data = stop_data;
   worker->cb_stop_func = stop_callback;
-  worker->closing = false;
 
   worker->rs_queue = hsk_rs_queue_alloc();
   if (!worker->rs_queue) {
     hsk_rs_worker_log(worker, "failed to create response queue");
+    goto fail;
+  }
+
+  worker->rs_pending = hsk_rs_pending_alloc();
+  if (!worker->rs_pending) {
+    hsk_rs_worker_log(worker, "failed to create pending request queue");
     goto fail;
   }
 
@@ -172,7 +355,7 @@ hsk_rs_worker_uninit(hsk_rs_worker_t *worker) {
   // worker if _init() fails.
 
   // Can't destroy while still closing.
-  assert(!worker->closing);
+  assert(!worker->rs_pending || !hsk_rs_pending_exiting(worker->rs_pending));
 
   // Can't destroy while worker is still running.
   assert(!worker->ub);
@@ -180,6 +363,11 @@ hsk_rs_worker_uninit(hsk_rs_worker_t *worker) {
   free_async(worker->rs_quit_async);
 
   free_async(worker->rs_async);
+
+  if (worker->rs_pending) {
+    hsk_rs_pending_free(worker->rs_pending);
+    worker->rs_pending = NULL;
+  }
 
   if (worker->rs_queue) {
     hsk_rs_queue_free(worker->rs_queue);
@@ -190,7 +378,7 @@ hsk_rs_worker_uninit(hsk_rs_worker_t *worker) {
 int
 hsk_rs_worker_open(hsk_rs_worker_t *worker, struct ub_ctx *ub) {
   // Can't open if closing or already open.
-  assert(!worker->closing);
+  assert(!hsk_rs_pending_exiting(worker->rs_pending));
   assert(!worker->ub);
 
   // Start the worker thread.  Set unbound context to indicate that the thread
@@ -209,44 +397,27 @@ hsk_rs_worker_open(hsk_rs_worker_t *worker, struct ub_ctx *ub) {
 
 bool
 hsk_rs_worker_is_open(hsk_rs_worker_t *worker) {
-  // If we're closing, the worker is open, don't read ub.  Otherwise, we're open
-  // if ub is set.
-  return !worker->closing || worker->ub;
+  return worker->ub;
 }
 
 void
 hsk_rs_worker_close(hsk_rs_worker_t *worker) {
   // No effect if already closing
-  if (worker->closing)
+  if (hsk_rs_pending_exiting(worker->rs_pending))
     return;
 
   // Must be open
   assert(worker->ub);
 
-  // Can't read worker->ub any more from the main thread once we tell the thread
-  // to close.
-  worker->closing = true;
-
-  // We need to tell the libunbound worker to exit - wake up the thread and
-  // clear ub on that thread.
+  // We need to tell the libunbound worker to exit - wake it up by signaling
+  // the waitable count.
   //
-  // libunbound doesn't give us a good way to do this, the only way is to
-  // issue a dummy query and do this in the callback on the worker thread.
-  //
-  // This works whether the request is successful or not.  As long as the
-  // authoritative server initialized, it'll complete quickly (even if it could
-  // not reach any peers).  If the authoritative server did not initialize, it
-  // will unfortunately wait for a timeout.
-  //
-  // On Unix, we could poll unbound's file descriptor manually with another
-  // file descriptor to allow us to wake the thread another way.  On Windows
-  // though, libunbound does not provide any access to its WSAEVENT to do the
-  // same thing; there's no other way to do this.
+  // This allows the worker thread to exit if nothing is going on in libunbound.
+  // It could already be inside a ub_wait() though - if there are any ongoing
+  // requests, this attempts to cancel them.  ub_wait() returns when there are
+  // no more pending requests.
   hsk_rs_worker_log(worker, "stopping libunbound worker...\n");
-  int rc = ub_resolve_async(worker->ub, ".", HSK_DNS_NS, HSK_DNS_IN,
-                            (void *)worker, after_resolve_shutdown, NULL);
-  if (rc != 0)
-    hsk_rs_worker_log(worker, "cannot stop worker thread: %s\n", ub_strerror(rc));
+  hsk_rs_pending_exit(worker->rs_pending);
 }
 
 hsk_rs_worker_t *
@@ -279,26 +450,45 @@ hsk_rs_worker_resolve(hsk_rs_worker_t *worker, char *name, int rrtype,
     return HSK_EBADARGS;
 
   // Can't resolve when closing or not open
-  if (worker->closing || !worker->ub)
+  if (hsk_rs_pending_exiting(worker->rs_pending) || !worker->ub)
     return HSK_EFAILURE;
 
   // Hold the callback data/func in a response object.  When the results come
   // in, we'll fill in the rest of this object and add it to the result queue.
   hsk_rs_rsp_t *rsp = malloc(sizeof(hsk_rs_rsp_t));
-  rsp->next = NULL;
+  rsp->prev = rsp->next = NULL;
   rsp->cb_data = data;
   rsp->cb_func = callback;
   rsp->worker = worker;
+  rsp->async_id = 0;
+  rsp->result = NULL;
   rsp->status = 0;
 
+  // Enqueue before attempting to send; we have to do this before sending to
+  // avoid racing with the callback.
+  hsk_rs_pending_enqueue(worker->rs_pending, rsp);
+
   int rc = ub_resolve_async(worker->ub, name, rrtype, rrclass, (void *)rsp,
-                            after_resolve_onthread, NULL);
+                            after_resolve_onthread, &rsp->async_id);
   if (rc) {
+    // Remove the response since it couldn't be sent.
+    hsk_rs_pending_remove(worker->rs_pending, rsp);
     hsk_rs_worker_log(worker, "unbound error: %s\n", ub_strerror(rc));
     return HSK_EFAILURE;
   }
+  hsk_rs_worker_log(worker, "request %d: %s\n", rsp->async_id, name);
 
   return HSK_SUCCESS;
+}
+
+static void
+hsk_rs_pending_log(hsk_rs_pending_t *pending, const char *fmt, ...) {
+  printf("rs_pending: ");
+
+  va_list args;
+  va_start(args, fmt);
+  vprintf(fmt, args);
+  va_end(args);
 }
 
 static void
@@ -344,25 +534,19 @@ static void
 run_unbound_worker(void *arg) {
   hsk_rs_worker_t *worker = (hsk_rs_worker_t *)arg;
 
-  while(worker->ub) {
+  // Annoyingly, ub_wait() does not actually wait if there are no outstanding
+  // requests.  To prevent a busy-wait when there's no work to do, we have to
+  // keep track of the outstanding requests manually and use a condition
+  // variable to block on them.  (libunbound already knows the count, but it
+  // doesn't give us any access to it.)
+  while(hsk_rs_pending_wait(worker->rs_pending)) {
+    // Not modified while worker is running
+    assert(worker->ub);
     ub_wait(worker->ub);
   }
 
+  // hsk_rs_pending_wait() returned false; worker was signaled to exit.
   uv_async_send(worker->rs_quit_async);
-}
-
-static void
-after_resolve_shutdown(void *data, int status, struct ub_result *result) {
-  ub_resolve_free(result);
-
-  hsk_rs_worker_t *worker = (hsk_rs_worker_t *)data;
-
-  // Clear this to stop the worker event loop.  This is safe because we've
-  // synced up both threads to ensure they're not reading this - the main thread
-  // won't read it any more at all (it's waiting for the worker thread to exit
-  // after _close() was called), and we're inside a ub_wait() on the worker
-  // thread.
-  worker->ub = NULL;
 }
 
 // Handle a resolve result on the libunbound worker thread, dispatch back to the
@@ -374,6 +558,9 @@ after_resolve_onthread(void *data, int status, struct ub_result *result) {
 
   rsp->result = result;
   rsp->status = status;
+
+  // This request finished, remove it from the pending queue.
+  hsk_rs_pending_remove(worker->rs_pending, rsp);
 
   // Enqueue the response.  This is safe to do on the worker thread:
   // - The worker->rs_queue pointer is not modified after initialization until
@@ -418,7 +605,11 @@ after_quit_async(uv_async_t *async) {
   // destroyed until _close() completes.
   assert(worker);
 
-  worker->closing = false;
+  uv_thread_join(&worker->rs_thread);
+
+  hsk_rs_pending_reset(worker->rs_pending);
+  // Worker has exited, could be opened again at this point
+  worker->ub = NULL;
 
   hsk_rs_worker_log(worker, "libunbound worker stopped\n");
 

--- a/src/rs_worker.c
+++ b/src/rs_worker.c
@@ -1,0 +1,347 @@
+#include "config.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <unbound.h>
+
+#include "dns.h"
+#include "error.h"
+#include "rs_worker.h"
+#include "uv.h"
+
+/*
+ * Prototypes
+ */
+static void
+hsk_rs_worker_log(hsk_rs_worker_t *ns, const char *fmt, ...);
+
+static void
+after_close_free(uv_handle_t *handle);
+
+static void
+run_unbound_worker(void *arg);
+
+static void
+after_resolve_shutdown(void *data, int status, struct ub_result *result);
+
+static void
+after_resolve_onthread(void *data, int status, struct ub_result *result);
+
+static void
+after_resolve_async(uv_async_t *async);
+
+/*
+ * Response Queue
+ */
+int
+hsk_rs_queue_init(hsk_rs_queue_t *queue) {
+  if (uv_mutex_init(&queue->mutex))
+    return HSK_EFAILURE;
+  queue->head = NULL;
+  queue->tail = NULL;
+
+  return HSK_SUCCESS;
+}
+
+void
+hsk_rs_queue_uninit(hsk_rs_queue_t *queue) {
+  hsk_rs_rsp_t *current = queue->head;
+  while (current) {
+    hsk_rs_rsp_t *next = current->next;
+    free(current);
+    current = next;
+  }
+
+  uv_mutex_destroy(&queue->mutex);
+}
+
+hsk_rs_queue_t *
+hsk_rs_queue_alloc() {
+  hsk_rs_queue_t *queue = malloc(sizeof(hsk_rs_queue_t));
+  if (!queue)
+    return NULL;
+
+  if (hsk_rs_queue_init(queue) != HSK_SUCCESS) {
+    free(queue);
+    return NULL;
+  }
+
+  return queue;
+}
+
+void
+hsk_rs_queue_free(hsk_rs_queue_t *queue) {
+  if(queue) {
+    hsk_rs_queue_uninit(queue);
+    free(queue);
+  }
+}
+
+// Dequeue the oldest queued response - thread-safe.
+// Returned object is now owned by the caller; returns nullptr if there is
+// nothing queued.
+hsk_rs_rsp_t *
+hsk_rs_queue_dequeue(hsk_rs_queue_t *queue) {
+  uv_mutex_lock(&queue->mutex);
+
+  hsk_rs_rsp_t *oldest = queue->head;
+  if (oldest) {
+    queue->head = oldest->next;
+    oldest->next = NULL;
+    // If this was the only queued request, clear tail too
+    if(queue->tail == oldest)
+      queue->tail = NULL;
+  }
+
+  uv_mutex_unlock(&queue->mutex);
+
+  return oldest;
+}
+
+// Enqueue a response - thread-safe.
+// The queue takes ownership of the response (until it's popped off again).
+void
+hsk_rs_queue_enqueue(hsk_rs_queue_t *queue, hsk_rs_rsp_t *rsp) {
+  uv_mutex_lock(&queue->mutex);
+
+  if (!queue->tail) {
+    // There were no requests queued; this one becomes head and tail
+    assert(!queue->head);   // Invariant - set and cleared together
+    queue->head = rsp;
+    queue->tail = rsp;
+  }
+  else {
+    // There are requests queued already, add this one to the tail
+    queue->tail->next = rsp;
+    queue->tail = rsp;
+  }
+
+  uv_mutex_unlock(&queue->mutex);
+}
+
+/*
+ * Response worker thread
+ */
+int
+hsk_rs_worker_init(hsk_rs_worker_t *worker, uv_loop_t *loop, struct ub_ctx *ub) {
+  if (!worker || !loop || !ub)
+    return HSK_EBADARGS;
+
+  worker->rs_queue = NULL;
+  worker->rs_async = NULL;
+  worker->ub = NULL;
+
+  worker->rs_queue = hsk_rs_queue_alloc();
+  if (!worker->rs_queue) {
+    hsk_rs_worker_log(worker, "failed to create response queue");
+    goto fail;
+  }
+
+  // Allocate this separately on the heap because uv_close() is asynchronous.
+  worker->rs_async = malloc(sizeof(uv_async_t));
+  if (!worker->rs_async) {
+    hsk_rs_worker_log(worker, "out of memory");
+    goto fail;
+  }
+
+  // Initialize the async and set data if successful.  (This also indicates to
+  // the cleanup logic that the async needs to be closed.)
+  worker->rs_async->data = NULL;
+  if (uv_async_init(loop, worker->rs_async, after_resolve_async)) {
+    hsk_rs_worker_log(worker, "failed to create libuv async event");
+    goto fail;
+  }
+  worker->rs_async->data = (void *)worker;
+
+  // Start the worker thread.  Set unbound context to indicate that the thread
+  // is running.  If it starts, we can no longer write worker->ub until we sync
+  // up both threads again in _uninit().
+  worker->ub = ub;
+  if (uv_thread_create(&worker->rs_thread, run_unbound_worker, (void *)worker)) {
+    hsk_rs_worker_log(worker, "failed to create libuv worker thread");
+    // Failed to start, not running.
+    worker->ub = NULL;
+    goto fail;
+  }
+
+  return HSK_SUCCESS;
+
+fail:
+  hsk_rs_worker_uninit(worker);
+
+  return HSK_EFAILURE;
+}
+
+void
+hsk_rs_worker_uninit(hsk_rs_worker_t *worker) {
+  // Note that _uninit() is also used to clean up a partially-constructed
+  // worker if _init() fails.
+
+  if (worker->ub) {
+    // We need to tell the libunbound worker to exit - wake up the thread and
+    // clear ub on that thread.
+    //
+    // libunbound doesn't give us a good way to do this, the only way is to
+    // issue a dummy query and do this in the callback on the worker thread.
+    //
+    // On Unix, we could poll unbound's file descriptor manually with another
+    // file descriptor to allow us to wake the thread another way.  On Windows
+    // though, libunbound does not provide any access to its WSAEVENT to do the
+    // same thing; there's no other way to do this.
+    int rc = ub_resolve_async(worker->ub, ".", HSK_DNS_NS, HSK_DNS_IN,
+                              (void *)worker, after_resolve_shutdown, NULL);
+    if (rc != 0)
+      hsk_rs_worker_log(worker, "cannot shut down worker thread: %s\n", ub_strerror(rc));
+    else
+      uv_thread_join(&worker->rs_thread);
+  }
+
+  if (worker->rs_async) {
+    // If it was also initialized, close it and free asynchronously
+    if (worker->rs_async->data) {
+      worker->rs_async->data = NULL;
+      uv_close((uv_handle_t *)worker->rs_async, after_close_free);
+      worker->rs_async = NULL;
+    }
+    else {
+      // Wasn't initialized, just free memory
+      free(worker->rs_async);
+      worker->rs_async = NULL;
+    }
+  }
+
+  if (worker->rs_queue) {
+    hsk_rs_queue_free(worker->rs_queue);
+    worker->rs_queue = NULL;
+  }
+}
+
+hsk_rs_worker_t *
+hsk_rs_worker_alloc(uv_loop_t *loop, struct ub_ctx *ub) {
+  hsk_rs_worker_t *worker = malloc(sizeof(hsk_rs_worker_t));
+  if (!worker)
+    return NULL;
+
+  if (hsk_rs_worker_init(worker, loop, ub) != HSK_SUCCESS) {
+    free(worker);
+    return NULL;
+  }
+
+  return worker;
+}
+
+void
+hsk_rs_worker_free(hsk_rs_worker_t *worker) {
+  if(worker) {
+    hsk_rs_worker_uninit(worker);
+    free(worker);
+  }
+}
+
+int
+hsk_rs_worker_resolve(hsk_rs_worker_t *worker, char *name, int rrtype,
+                      int rrclass, void *data, ub_callback_type callback) {
+  if (!callback)
+    return HSK_EBADARGS;
+
+  // Hold the callback data/func in a response object.  When the results come
+  // in, we'll fill in the rest of this object and add it to the result queue.
+  hsk_rs_rsp_t *rsp = malloc(sizeof(hsk_rs_rsp_t));
+  rsp->next = NULL;
+  rsp->cb_data = data;
+  rsp->cb_func = callback;
+  rsp->worker = worker;
+  rsp->status = 0;
+
+  int rc = ub_resolve_async(worker->ub, name, rrtype, rrclass, (void *)rsp,
+                            after_resolve_onthread, NULL);
+  if (rc) {
+    hsk_rs_worker_log(worker, "unbound error: %s\n", ub_strerror(rc));
+    return HSK_EFAILURE;
+  }
+
+  return HSK_SUCCESS;
+}
+
+static void
+hsk_rs_worker_log(hsk_rs_worker_t *worker, const char *fmt, ...) {
+  printf("rs_worker: ");
+
+  va_list args;
+  va_start(args, fmt);
+  vprintf(fmt, args);
+  va_end(args);
+}
+
+static void
+after_close_free(uv_handle_t *handle) {
+  free(handle);
+}
+
+static void
+run_unbound_worker(void *arg) {
+  hsk_rs_worker_t *worker = (hsk_rs_worker_t *)arg;
+
+  while(worker->ub) {
+    ub_wait(worker->ub);
+  }
+}
+
+static void
+after_resolve_shutdown(void *data, int status, struct ub_result *result) {
+  ub_resolve_free(result);
+
+  hsk_rs_worker_t *worker = (hsk_rs_worker_t *)data;
+
+  // Clear this to stop the worker event loop.  This is safe because we've
+  // synced up both threads to ensure they're not reading this - the main thread
+  // won't read it any more at all (it's just going to wait for the worker to
+  // exit with a _join()), and we're inside a ub_wait() on the worker thread.
+  worker->ub = NULL;
+}
+
+// Handle a resolve result on the libunbound worker thread, dispatch back to the
+// libuv event loop.
+static void
+after_resolve_onthread(void *data, int status, struct ub_result *result) {
+  hsk_rs_rsp_t *rsp = (hsk_rs_rsp_t *)data;
+  hsk_rs_worker_t *worker = rsp->worker;
+
+  rsp->result = result;
+  rsp->status = status;
+
+  // Enqueue the response.  This is safe to do on the worker thread:
+  // - The worker->rs_queue pointer is not modified after initialization until
+  //   the worker thread has been stopped
+  // - The hsk_rs_queue_t object itself is thread-safe
+  hsk_rs_queue_enqueue(worker->rs_queue, rsp);
+
+  // Queue an async event to process the response on the libuv event loop.
+  // Like rs_queue, the rs_async pointer is safe to use because it's not
+  // modified until the libunbound worker is stopped.
+  uv_async_send(worker->rs_async);
+}
+
+static void
+after_resolve_async(uv_async_t *async) {
+  hsk_rs_worker_t *worker = async->data;
+
+  // Since uv_close() is async, it might be possible to process this event after
+  // the worker is shut down but before the async is closed.
+  if(!worker)
+    return;
+
+  // Dequeue and process all events in the queue - libuv coalesces calls to
+  // uv_async_send().
+  hsk_rs_rsp_t *rsp = hsk_rs_queue_dequeue(worker->rs_queue);
+  while(rsp) {
+    rsp->cb_func(rsp->cb_data, rsp->status, rsp->result);
+
+    // Free the response element - the callback is responsible for the unbound
+    // result
+    free(rsp);
+
+    rsp = hsk_rs_queue_dequeue(worker->rs_queue);
+  }
+}

--- a/src/rs_worker.h
+++ b/src/rs_worker.h
@@ -1,0 +1,84 @@
+#ifndef _HSK_RS_WORKER_
+#define _HSK_RS_WORKER_
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include <unbound.h>
+
+#include "uv.h"
+
+/*
+ * Types
+ */
+
+struct _hsk_rs_rsp_t;
+typedef struct _hsk_rs_rsp_t hsk_rs_rsp_t;
+
+// Thread-safe response queue - synchronized with a mutex; responses enqueued
+// from worker thread and dequeued on libuv event loop thread.
+typedef struct {
+  uv_mutex_t mutex;
+  hsk_rs_rsp_t *head;  // Oldest response
+  hsk_rs_rsp_t *tail;  // Newest response
+} hsk_rs_queue_t;
+
+// Response worker thread - relays libunbound results from its worker thread to
+// the libuv event loop thread.
+typedef struct {
+  // Queue of results received from libunbound.
+  hsk_rs_queue_t *rs_queue;
+  // Async used to signal back to the libuv event loop.
+  uv_async_t *rs_async;
+  uv_thread_t rs_thread;
+  // The unbound context processed by the worker thread.  Indicates whether the
+  // worker thread event loop is running.
+  struct ub_ctx *ub;
+} hsk_rs_worker_t;
+
+// Response data from libunbound - used to queue responses back to the libuv
+// event loop in a linked list
+struct _hsk_rs_rsp_t {
+  hsk_rs_rsp_t *next;
+  // Callback and data given to hsk_rs_worker_resolve()
+  void *cb_data;
+  ub_callback_type cb_func;
+  union {
+    // Before the response is received, store a pointer back to the worker so we
+    // can enqueue the response.
+    hsk_rs_worker_t *worker;
+    // After the response is enqueued, store the result from libunbound
+    struct ub_result *result;
+  };
+  // Response status from libunbound
+  int status;
+};
+
+/*
+ * Response worker thread
+ */
+
+// Initialize with the libuv event loop where results are handled and the
+// libunbound context to process on the worker thread.  This starts the worker
+// thread.
+int
+hsk_rs_worker_init(hsk_rs_worker_t *worker, uv_loop_t *loop, struct ub_ctx *ub);
+
+void
+hsk_rs_worker_uninit(hsk_rs_worker_t *worker);
+
+hsk_rs_worker_t *
+hsk_rs_worker_alloc(uv_loop_t *loop, struct ub_ctx *ub);
+
+void
+hsk_rs_worker_free(hsk_rs_worker_t *worker);
+
+// Resolve a name.  The name, rrtype, and rrclass parameters are passed through
+// to libunbound.  The result callback occurs in the libuv event loop.  When the
+// callback occurs, ownership of the ub_result is passed to the callback.
+int
+hsk_rs_worker_resolve(hsk_rs_worker_t *worker, char *name, int rrtype,
+                      int rrclass, void *data, ub_callback_type callback);
+
+#endif

--- a/src/rs_worker.h
+++ b/src/rs_worker.h
@@ -18,17 +18,44 @@ typedef struct _hsk_rs_rsp_t hsk_rs_rsp_t;
 
 // Thread-safe response queue - synchronized with a mutex; responses enqueued
 // from worker thread and dequeued on libuv event loop thread.
+//
+// This queue holds responses receieved from libunbound to dispatch them back
+// to the libuv event loop.
 typedef struct {
   uv_mutex_t mutex;
   hsk_rs_rsp_t *head;  // Oldest response
   hsk_rs_rsp_t *tail;  // Newest response
 } hsk_rs_queue_t;
 
+// Waitable pending request queue.  This holds requests that have been sent to
+// libunbound until they receive a response on the libunbound worker thread.
+//
+// hsk_rs_pending_wait() waits until there is at least one pending request
+// (returns immediately if it already is, otherwise blocks until it becomes
+// nonzero).
+//
+// Also provides an 'exit' flag that tells the worker thread to exit.  A wait()
+// ends when either the count is nonzero or the worker is supposed to exit.
+typedef struct {
+  // Mutex to protect count
+  uv_mutex_t mutex;
+  // Condition signaled whenever count is incremented
+  uv_cond_t cond;
+  // Linked list of outstanding requests
+  hsk_rs_rsp_t *head; // Oldest request
+  hsk_rs_rsp_t *tail; // Newest request
+  // Whether worker should exit.
+  bool exit;
+} hsk_rs_pending_t;
+
 // Response worker thread - relays libunbound results from its worker thread to
 // the libuv event loop thread.
 typedef struct {
   // Queue of results received from libunbound.
   hsk_rs_queue_t *rs_queue;
+  // Pending request queue used to block the worker when no requests are being
+  // serviced
+  hsk_rs_pending_t *rs_pending;
   // Async used to signal results back to the libuv event loop.
   uv_async_t *rs_async;
   // Async used to signal that the worker thread is quitting (the worker can be
@@ -40,36 +67,46 @@ typedef struct {
   void (*cb_stop_func)(void *);
   // The unbound context processed by the worker thread.  Indicates whether the
   // worker thread event loop is running.
-  // Once the worker is started, both threads will read this variable, so it
-  // can't be modified before _close() is called (closing prevents the main
-  // thread from reading it, and _close() wakes the worker to have it clear ub
-  // and return).
+  // This is only written from the main thread while the worker is not running.
   struct ub_ctx *ub;
-  // Indicates that we've signaled the worker thread to exit (we can no longer
-  // read ub).
-  bool closing;
 } hsk_rs_worker_t;
 
 // Response data from libunbound - used to queue responses back to the libuv
 // event loop in a linked list
 struct _hsk_rs_rsp_t {
+  hsk_rs_rsp_t *prev;
   hsk_rs_rsp_t *next;
   // Callback and data given to hsk_rs_worker_resolve()
   void *cb_data;
   ub_callback_type cb_func;
-  union {
-    // Before the response is received, store a pointer back to the worker so we
-    // can enqueue the response.
-    hsk_rs_worker_t *worker;
-    // After the response is enqueued, store the result from libunbound
-    struct ub_result *result;
-  };
+  // The worker that enqueued the response
+  hsk_rs_worker_t *worker;
+  // When the request is pending, the libunbound async ID
+  int async_id;
+  // After the response is enqueued, the result from libunbound
+  struct ub_result *result;
   // Response status from libunbound
   int status;
 };
 
 /*
  * Response worker thread
+ *
+ * This manages async requests to libunbound and the worker thread that passes
+ * results back to the libuv event loop.
+ *
+ * libunbound requests go through two queues:
+ * - When the request is made, it enters the "pending request" queue
+ *   (hsk_rs_pending_t)
+ * - When the response is received from libunbound, it moves to the "response"
+ *   queue (hsk_rs_queue_t)
+ * - When the callback is delivered in the libuv event loop, it is removed from
+ *   the response queue
+ *
+ * The two queues are necessary to avoid busy-waiting in the worker thread, to
+ * hand responses back to the libuve event loop, and to be able to cancel
+ * outstanding requests and shut down the worker thread.  They also ensure we
+ * don't leak any memory for in-flight requests that are canceled at shutdown.
  */
 
 // Initialize with the libuv event loop where results are handled and the

--- a/src/rs_worker.h
+++ b/src/rs_worker.h
@@ -29,12 +29,25 @@ typedef struct {
 typedef struct {
   // Queue of results received from libunbound.
   hsk_rs_queue_t *rs_queue;
-  // Async used to signal back to the libuv event loop.
+  // Async used to signal results back to the libuv event loop.
   uv_async_t *rs_async;
+  // Async used to signal that the worker thread is quitting (the worker can be
+  // destroyed now)
+  uv_async_t *rs_quit_async;
   uv_thread_t rs_thread;
+  // Stop callback and data
+  void *cb_stop_data;
+  void (*cb_stop_func)(void *);
   // The unbound context processed by the worker thread.  Indicates whether the
   // worker thread event loop is running.
+  // Once the worker is started, both threads will read this variable, so it
+  // can't be modified before _close() is called (closing prevents the main
+  // thread from reading it, and _close() wakes the worker to have it clear ub
+  // and return).
   struct ub_ctx *ub;
+  // Indicates that we've signaled the worker thread to exit (we can no longer
+  // read ub).
+  bool closing;
 } hsk_rs_worker_t;
 
 // Response data from libunbound - used to queue responses back to the libuv
@@ -63,16 +76,32 @@ struct _hsk_rs_rsp_t {
 // libunbound context to process on the worker thread.  This starts the worker
 // thread.
 int
-hsk_rs_worker_init(hsk_rs_worker_t *worker, uv_loop_t *loop, struct ub_ctx *ub);
+hsk_rs_worker_init(hsk_rs_worker_t *worker, uv_loop_t *loop, void *stop_data,
+                   void (*stop_callback)(void *));
 
 void
 hsk_rs_worker_uninit(hsk_rs_worker_t *worker);
 
 hsk_rs_worker_t *
-hsk_rs_worker_alloc(uv_loop_t *loop, struct ub_ctx *ub);
+hsk_rs_worker_alloc(uv_loop_t *loop, void *stop_data,
+                    void (*stop_callback)(void *));
 
 void
 hsk_rs_worker_free(hsk_rs_worker_t *worker);
+
+int
+hsk_rs_worker_open(hsk_rs_worker_t *worker, struct ub_ctx *ub);
+
+bool
+hsk_rs_worker_is_open(hsk_rs_worker_t *worker);
+
+// Close the worker.  The worker must be closed after it's successfully opened,
+// and it can't be destroyed until the close completes (indicated by calling the
+// stop_callback passed to _alloc()/_init()).
+//
+// Once _close() is called, calls to _resolve() will fail synchronously.
+void
+hsk_rs_worker_close(hsk_rs_worker_t *worker);
 
 // Resolve a name.  The name, rrtype, and rrclass parameters are passed through
 // to libunbound.  The result callback occurs in the libuv event loop.  When the

--- a/src/signals.c
+++ b/src/signals.c
@@ -1,0 +1,124 @@
+#include "config.h"
+
+#include "error.h"
+#include "signals.h"
+#include "utils.h"
+
+/*
+ * Prototypes
+ */
+static uv_signal_t *
+alloc_signal(hsk_signals_t *signals, uv_loop_t *loop, int signum);
+
+static void
+free_signal(uv_signal_t *signal);
+
+static void
+signal_handler(uv_signal_t *signal, int signum);
+
+/*
+ * Signal handler
+ */
+int
+hsk_signals_init(hsk_signals_t *signals, uv_loop_t *loop, void *data,
+                 void (*callback)()) {
+  if (!signals || !loop || !callback)
+    return HSK_EBADARGS;
+
+  signals->cb_data = data;
+  signals->cb_func = callback;
+
+  signals->sigint = alloc_signal(signals, loop, SIGINT);
+  if (!signals->sigint)
+    goto fail;
+
+  signals->sigterm = alloc_signal(signals, loop, SIGTERM);
+  if (!signals->sigterm)
+    goto fail;
+
+  return HSK_SUCCESS;
+
+fail:
+  hsk_signals_uninit(signals);
+
+  return HSK_EFAILURE;
+}
+
+void
+hsk_signals_uninit(hsk_signals_t *signals) {
+  free_signal(signals->sigterm);
+  signals->sigterm = NULL;
+  free_signal(signals->sigint);
+  signals->sigterm = NULL;
+}
+
+hsk_signals_t *
+hsk_signals_alloc(uv_loop_t *loop, void *data, void (*callback)()) {
+  hsk_signals_t *signals = malloc(sizeof(hsk_signals_t));
+  if (!signals)
+    return NULL;
+
+  if (hsk_signals_init(signals, loop, data, callback) != HSK_SUCCESS) {
+    free(signals);
+    return NULL;
+  }
+
+  return signals;
+}
+
+void
+hsk_signals_free(hsk_signals_t *signals) {
+  if (signals) {
+    hsk_signals_uninit(signals);
+    free(signals);
+  }
+}
+
+static uv_signal_t *
+alloc_signal(hsk_signals_t *signals, uv_loop_t *loop, int signum) {
+  // Allocate the signal
+  uv_signal_t *signal = malloc(sizeof(uv_signal_t));
+  if (!signal)
+    return NULL;
+
+  signal->data = NULL;
+
+  // Init the signal
+  if (uv_signal_init(loop, signal)) {
+    free(signal);
+    return NULL;
+  }
+
+  if (uv_signal_start(signal, signal_handler, signum))
+  {
+    // Free after async close
+    hsk_uv_close_free((uv_handle_t *)signal);
+    return NULL;
+  }
+
+  signal->data = (void *)signals;
+
+  return signal;
+}
+
+static void
+free_signal(uv_signal_t *signal) {
+  if (signal) {
+    signal->data = NULL;
+    uv_signal_stop(signal);
+    hsk_uv_close_free((uv_handle_t *)signal);
+  }
+}
+
+static void
+signal_handler(uv_signal_t *signal, int signum) {
+  hsk_signals_t *signals = (hsk_signals_t *)signal->data;
+
+  // Due to async close, might be possible to receive this after _uninit()
+  if (!signals)
+    return;
+
+  printf("signal: %d\n", signum);
+
+  signals->cb_func(signals->cb_data);
+}

--- a/src/signals.h
+++ b/src/signals.h
@@ -1,0 +1,40 @@
+#ifndef _HSK_SIGNALS_H_
+#define _HSK_SIGNALS_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "signals.h"
+#include "uv.h"
+
+/*
+ * Types
+ */
+typedef struct {
+  void *cb_data;
+  void (*cb_func)(void *);
+  uv_signal_t *sigint;
+  uv_signal_t *sigterm;
+} hsk_signals_t;
+
+/*
+ * Signal handler
+ *
+ * Handles SIGINT and SIGTERM signals.  When one of these signals occurs, the
+ * callback given is called in the libuv event loop.  (The callback should shut
+ * down the process.)
+ */
+int
+hsk_signals_init(hsk_signals_t *signals, uv_loop_t *loop, void *data,
+                 void (*callback)());
+
+void
+hsk_signals_uninit(hsk_signals_t *signals);
+
+hsk_signals_t *
+hsk_signals_alloc(uv_loop_t *loop, void *data, void (*callback)());
+
+void
+hsk_signals_free(hsk_signals_t *signals);
+
+#endif

--- a/src/utils.c
+++ b/src/utils.c
@@ -8,6 +8,8 @@
 #include <stdlib.h>
 #include <time.h>
 
+#include "uv.h"
+
 // Taken from:
 // https://github.com/wahern/dns/blob/master/src/dns.c
 #ifndef _HSK_RANDOM
@@ -223,4 +225,15 @@ hsk_to_lower(char *name) {
       *s += ' ';
     s += 1;
   }
+}
+
+static void
+after_close_free(uv_handle_t *handle) {
+  free(handle);
+}
+
+void
+hsk_uv_close_free(uv_handle_t *handle) {
+  if (handle)
+    uv_close(handle, after_close_free);
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -5,6 +5,8 @@
 #include <stdbool.h>
 #include <stdlib.h>
 
+#include "uv.h"
+
 int64_t
 hsk_now(void);
 
@@ -51,4 +53,11 @@ hsk_hex_decode(const char *str, uint8_t *data);
 
 void
 hsk_to_lower(char *name);
+
+// Close and then free a libuv handle (with free()).
+// libuv specifically documents that the handle memory cannot be freed until the
+// async close callback is invoked, so this frees the handle in that callback.
+void
+hsk_uv_close_free(uv_handle_t *handle);
+
 #endif


### PR DESCRIPTION
Support native Windows builds with Msys2/MinGW, using the MinGW libunbound package.

The major issue was that libunbound can't be hooked up to the libuv event loop with a file descriptor like on Unix (libunbound does not use a pipe on Windows, and libuv on Windows can only poll sockets anyway).
Instead, create a worker thread to operate libunbound, using libuv's threading primitives.  Results are queued back to the libuv event loop using a libuv async.
hnsd now shuts down cleanly on SIGINT and SIGTERM too, realized it was not doing this when I could not test the thread shutdown code.  This uncovered minor issues in the pool shutdown code, which are fixed.
The libunbound path can also be set when configuring, we're building libunbound from source in order to stay on the same version on all platforms.