### PR TITLE
dns: fix loop in hsk_dns_label_decode_tlsa

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -2800,6 +2800,8 @@ hsk_dns_label_decode_tlsa(const char *name, char *protocol, uint16_t *port) {
 
     if (word > 0xffff)
       return false;
+
+    s += 1;
   }
 
   if (port)


### PR DESCRIPTION
`hsk_dns_label_decode_tlsa` was never decoding the port properly. In fact, it the port's first character was `'0'`, it would enter an infinite loop.