### PR TITLE
pool: handle both clearnet and brontide peers

### DIFF
--- a/src/addr.c
+++ b/src/addr.c
@@ -375,7 +375,7 @@ hsk_addr_from_string(hsk_addr_t *addr, const char *src, uint16_t port) {
 
   uint16_t sin_port = port;
 
-  if (port && port_s) {
+  if (port_s) {
     int i = 0;
     uint32_t word = 0;
     char *s = port_s;
@@ -398,6 +398,8 @@ hsk_addr_from_string(hsk_addr_t *addr, const char *src, uint16_t port) {
     sin_port = (uint16_t)word;
   } else if (!port) {
     sin_port = at ? HSK_BRONTIDE_PORT : HSK_PORT;
+  } else {
+    sin_port = port;
   }
 
   uint8_t sin_addr[16];

--- a/src/addr.c
+++ b/src/addr.c
@@ -396,8 +396,8 @@ hsk_addr_from_string(hsk_addr_t *addr, const char *src, uint16_t port) {
     }
 
     sin_port = (uint16_t)word;
-  } else if (!port && port_s) {
-    return false;
+  } else if (!port) {
+    sin_port = at ? HSK_BRONTIDE_PORT : HSK_PORT;
   }
 
   uint8_t sin_addr[16];
@@ -940,7 +940,11 @@ hsk_addr_print(const hsk_addr_t *addr, const char *prefix) {
   char host[HSK_MAX_HOST];
   assert(hsk_addr_to_string(addr, host, HSK_MAX_HOST, HSK_BRONTIDE_PORT));
 
+  char b32[54];
+  hsk_base32_encode(addr->key, 33, b32, false);
+
   printf("%saddr\n", prefix);
+  printf("%skey=%s\n", prefix, b32);
   printf("%s  type=%d\n", prefix, addr->type);
   printf("%s  host=%s\n", prefix, host);
 }

--- a/src/addrmgr.c
+++ b/src/addrmgr.c
@@ -57,7 +57,7 @@ hsk_addrman_init(hsk_addrman_t *am, const hsk_timedata_t *td) {
   const char **seed;
   for (seed = hsk_seeds; *seed; seed++) {
     hsk_addr_t addr;
-    assert(hsk_addr_from_string(&addr, *seed, HSK_BRONTIDE_PORT));
+    assert(hsk_addr_from_string(&addr, *seed, 0));
     assert(hsk_addrman_add_addr(am, &addr));
   }
 

--- a/src/pool.h
+++ b/src/pool.h
@@ -56,7 +56,7 @@ typedef struct hsk_peer_s {
   hsk_chain_t *chain;
   uv_loop_t *loop;
   uv_tcp_t socket;
-  hsk_brontide_t brontide;
+  hsk_brontide_t *brontide;
   uint64_t id;
   char host[HSK_MAX_HOST];
   hsk_addr_t addr;


### PR DESCRIPTION
Also,

* Use default port depending on whether addr has '@'

* hsk_addr_print also print key

* hsk_addr_from_string - accept 0 to use default port (auto-selects clearnet/brontide based on addr string)

* skip gossiped addr if it has key (untrusted key)