### PR TITLE
pool: handle both clearnet and brontide peers + clearnet peer discovery

### DIFF
--- a/src/addr.c
+++ b/src/addr.c
@@ -375,7 +375,7 @@ hsk_addr_from_string(hsk_addr_t *addr, const char *src, uint16_t port) {
 
   uint16_t sin_port = port;
 
-  if (port && port_s) {
+  if (port_s) {
     int i = 0;
     uint32_t word = 0;
     char *s = port_s;
@@ -398,6 +398,8 @@ hsk_addr_from_string(hsk_addr_t *addr, const char *src, uint16_t port) {
     sin_port = (uint16_t)word;
   } else if (!port) {
     sin_port = at ? HSK_BRONTIDE_PORT : HSK_PORT;
+  } else {
+    sin_port = port;
   }
 
   uint8_t sin_addr[16];

--- a/src/addr.c
+++ b/src/addr.c
@@ -396,8 +396,8 @@ hsk_addr_from_string(hsk_addr_t *addr, const char *src, uint16_t port) {
     }
 
     sin_port = (uint16_t)word;
-  } else if (!port && port_s) {
-    return false;
+  } else if (!port) {
+    sin_port = at ? HSK_BRONTIDE_PORT : HSK_PORT;
   }
 
   uint8_t sin_addr[16];
@@ -940,7 +940,11 @@ hsk_addr_print(const hsk_addr_t *addr, const char *prefix) {
   char host[HSK_MAX_HOST];
   assert(hsk_addr_to_string(addr, host, HSK_MAX_HOST, HSK_BRONTIDE_PORT));
 
+  char b32[54];
+  hsk_base32_encode(addr->key, 33, b32, false);
+
   printf("%saddr\n", prefix);
+  printf("%skey=%s\n", prefix, b32);
   printf("%s  type=%d\n", prefix, addr->type);
   printf("%s  host=%s\n", prefix, host);
 }

--- a/src/addr.c
+++ b/src/addr.c
@@ -448,8 +448,7 @@ hsk_addr_to_string(
     if (!port)
       port = fb;
 
-    // XXX Not thread safe.
-    static char tmp[HSK_MAX_HOST];
+    char tmp[HSK_MAX_HOST];
 
     if (af == AF_INET6) {
       assert(len + need < HSK_MAX_HOST);
@@ -489,8 +488,7 @@ hsk_addr_to_full(
   char b32[54];
   hsk_base32_encode(addr->key, 33, b32, false);
 
-  // XXX Not thread safe.
-  static char tmp[HSK_MAX_HOST];
+  char tmp[HSK_MAX_HOST];
   sprintf(tmp, "%s@%s", b32, dst);
   strcpy(dst, tmp);
 
@@ -517,8 +515,7 @@ hsk_addr_to_at(const hsk_addr_t *addr, char *dst, size_t dst_len, uint16_t fb) {
     if (!port)
       port = fb;
 
-    // XXX Not thread safe.
-    static char tmp[HSK_MAX_HOST];
+    char tmp[HSK_MAX_HOST];
     sprintf(tmp, "%s@%u", dst, port);
     strcpy(dst, tmp);
   }

--- a/src/addrmgr.c
+++ b/src/addrmgr.c
@@ -57,7 +57,7 @@ hsk_addrman_init(hsk_addrman_t *am, const hsk_timedata_t *td) {
   const char **seed;
   for (seed = hsk_seeds; *seed; seed++) {
     hsk_addr_t addr;
-    assert(hsk_addr_from_string(&addr, *seed, HSK_BRONTIDE_PORT));
+    assert(hsk_addr_from_string(&addr, *seed, 0));
     assert(hsk_addrman_add_addr(am, &addr));
   }
 

--- a/src/pool.c
+++ b/src/pool.c
@@ -263,17 +263,23 @@ hsk_pool_set_seeds(hsk_pool_t *pool, const char *seeds) {
         continue;
       }
 
-      if (size >= HSK_MAX_HOST)
-        return false;
+      if (size >= HSK_MAX_HOST) {
+        hsk_pool_log(pool, "seed address exceeds maximum length allowed.\n");
+        continue;
+      }
 
       memcpy(&seed[0], &seeds[start], size);
       seed[size] = '\0';
 
-      if (!hsk_addr_from_string(&addr, seed, 0))
-        return false;
+      if (!hsk_addr_from_string(&addr, seed, 0)) {
+        hsk_pool_log(pool, "could not parse seed from string: %s\n", seed);
+        continue;
+      }
 
-      if (!hsk_addrman_add_addr(&pool->am, &addr))
-        return false;
+      if (!hsk_addrman_add_addr(&pool->am, &addr)) {
+        hsk_pool_log(pool, "could not add seed: %s\n", seed);
+        continue;
+      }
 
       start = i + 1;
     }

--- a/src/pool.c
+++ b/src/pool.c
@@ -896,6 +896,8 @@ hsk_peer_open(hsk_peer_t *peer, const hsk_addr_t *addr) {
   assert(peer && addr);
   assert(peer->pool && peer->loop && peer->state == HSK_STATE_DISCONNECTED);
 
+  peer->state = HSK_STATE_CONNECTING;
+
   hsk_pool_t *pool = (hsk_pool_t *)peer->pool;
   uv_loop_t *loop = pool->loop;
 
@@ -926,9 +928,6 @@ hsk_peer_open(hsk_peer_t *peer, const hsk_addr_t *addr) {
     free(conn);
     return HSK_EFAILURE;
   }
-
-  peer->state = HSK_STATE_CONNECTING;
-
 
   hsk_peer_t *peerIter, *next;
   uint64_t active = 0;

--- a/src/pool.c
+++ b/src/pool.c
@@ -92,6 +92,9 @@ static int
 hsk_peer_send_getheaders(hsk_peer_t *peer, const uint8_t *stop);
 
 static int
+hsk_peer_send_getaddr(hsk_peer_t *peer);
+
+static int
 hsk_peer_send_getproof(
   hsk_peer_t *peer,
   const uint8_t *name_hash,
@@ -1214,6 +1217,13 @@ hsk_peer_send_sendheaders(hsk_peer_t *peer) {
 }
 
 static int
+hsk_peer_send_getaddr(hsk_peer_t *peer) {
+  hsk_peer_log(peer, "sending getaddr\n");
+  hsk_version_msg_t msg = { .cmd = HSK_MSG_GETADDR };
+  return hsk_peer_send(peer, (hsk_msg_t *)&msg);
+}
+
+static int
 hsk_peer_send_getheaders(hsk_peer_t *peer, const uint8_t *stop) {
   hsk_peer_log(peer, "sending getheaders\n");
   hsk_getheaders_msg_t msg = { .cmd = HSK_MSG_GETHEADERS };
@@ -1265,6 +1275,13 @@ hsk_peer_handle_version(hsk_peer_t *peer, const hsk_version_msg_t *msg) {
   if (rc != HSK_SUCCESS)
     return rc;
 
+  // Discover more peers
+  rc = hsk_peer_send_getaddr(peer);
+
+  if (rc != HSK_SUCCESS)
+    return rc;
+
+  // Start syncing
   return hsk_peer_send_getheaders(peer, NULL);
 }
 

--- a/src/pool.c
+++ b/src/pool.c
@@ -1449,7 +1449,10 @@ hsk_peer_handle_headers(hsk_peer_t *peer, const hsk_headers_msg_t *msg) {
 
     if (rc != HSK_SUCCESS) {
       hsk_peer_log(peer, "failed adding block: %s\n", hsk_strerror(rc));
-      return rc;
+      if (rc == HSK_EDUPLICATE)
+        return HSK_SUCCESS;
+      else
+        return rc;
     }
 
     peer->headers += 1;

--- a/src/pool.c
+++ b/src/pool.c
@@ -929,6 +929,16 @@ hsk_peer_open(hsk_peer_t *peer, const hsk_addr_t *addr) {
 
   peer->state = HSK_STATE_CONNECTING;
 
+
+  hsk_peer_t *peerIter, *next;
+  uint64_t active = 0;
+  for (peerIter = pool->head; peerIter; peerIter = next) {
+    next = peerIter->next;
+    if (peerIter->state == HSK_STATE_HANDSHAKE)
+      active++;
+  }
+  hsk_pool_log(pool, "size: %d active: %d\n", pool->size, active);
+
   return HSK_SUCCESS;
 }
 

--- a/src/pool.c
+++ b/src/pool.c
@@ -383,17 +383,17 @@ hsk_pool_getaddr(hsk_pool_t *pool, hsk_addr_t *addr) {
 
 static int
 hsk_pool_refill(hsk_pool_t *pool) {
-  while (pool->size < pool->max_size) {
+  if (pool->size < pool->max_size) {
     hsk_addr_t addr;
 
     if (!hsk_pool_getaddr(pool, &addr)) {
       hsk_pool_debug(pool, "could not find suitable addr\n");
-      break;
+      return HSK_SUCCESS;
     }
 
     if (hsk_addr_has_key(&addr) && !hsk_ec_verify_pubkey(pool->ec, addr.key)) {
       hsk_addrman_remove_addr(&pool->am, &addr);
-      continue;
+      return HSK_SUCCESS;
     }
 
     hsk_peer_t *peer = hsk_peer_alloc(pool, hsk_addr_has_key(&addr));

--- a/src/pool.c
+++ b/src/pool.c
@@ -1585,7 +1585,10 @@ hsk_peer_on_read(hsk_peer_t *peer, const uint8_t *data, size_t data_len) {
     memcpy(peer->msg + peer->msg_pos, data, need);
     data += need;
     data_len -= need;
-    hsk_peer_parse(peer, peer->msg, peer->msg_len);
+    if (hsk_peer_parse(peer, peer->msg, peer->msg_len) != 0) {
+      hsk_peer_destroy(peer);
+      return;
+    }
   }
 
   memcpy(peer->msg + peer->msg_pos, data, data_len);

--- a/src/pool.h
+++ b/src/pool.h
@@ -56,7 +56,7 @@ typedef struct hsk_peer_s {
   hsk_chain_t *chain;
   uv_loop_t *loop;
   uv_tcp_t socket;
-  hsk_brontide_t brontide;
+  hsk_brontide_t *brontide;
   uint64_t id;
   char host[HSK_MAX_HOST];
   hsk_addr_t addr;

--- a/src/pool.h
+++ b/src/pool.h
@@ -60,7 +60,6 @@ typedef struct hsk_peer_s {
   uint64_t id;
   char host[HSK_MAX_HOST];
   hsk_addr_t addr;
-  uint16_t port;
   int state;
   uint8_t read_buffer[HSK_BUFFER_SIZE];
   int headers;


### PR DESCRIPTION
Replaces #35

We have no test suite so I'm just trying to launch with different combinations of params that crashed or didn't work before this PR. Closing hnsd is the only way to get a quick list of connected peers :-(

Testing:

- [x] No extra seeds: `$ ./hnsd` 

- [x] Lots of clearnet seeds: `$ ./hnsd -s 138.68.61.31,149.129.80.119,54.184.104.94,50.112.123.184,47.240.14.207,173.230.137.164,24.254.236.98,173.255.209.126,172.104.214.189,139.162.183.168,64.227.15.172,44.229.138.206,74.207.247.120,69.164.220.60,45.79.252.244,24.254.239.228`

- [x] Brontide peer that is NOT a hard coded default seed: `$ ./hnsd -s anfic6amfi2mpzjy4puf2bfogpvzfpmnu7tvn6eyq66pgtawoz53q@64.227.15.172`

- [x] Invalid seed: `$ ./hnsd -s irugheriughweiguhweirugheirugheirughpierughwieruhgpwierughpweirughpwieruhgpqeurhgpiqeury8345yogiuwrthgow45hgoiurthgiousrthgoiusrhtgiuhsrtgiouhsrtgiuhsrltgiuhsrlitghuslfghlsdfuhgsidufhglsduhfglksduhfglkshdflgkjhsdlfkjghsldkfjhglsdkjfhg`
```
chain (0): chain is fully synced
addrman: added addr: 165.22.151.242:44806
addrman: added addr: 172.104.214.189:44806
addrman: added addr: 173.255.209.126:44806
addrman: added addr: 172.104.177.177:44806
addrman: added addr: 139.162.183.168:44806
addrman: added addr: 74.207.247.120:44806
addrman: added addr: 45.79.134.225:44806
pool: seed address exceeds maximum length allowed.
pool: pool opened (size=8)
...
```

- [x] Seed that is already a hard coded default seed: `$  ./hnsd -s aonetsezqp4m52w4jpfq2gv3dggy2wqfwqtkfjyttgdidbvhgp5as@165.22.151.242`
```
chain (0): chain is fully synced
addrman: added addr: 165.22.151.242:44806
addrman: added addr: 172.104.214.189:44806
addrman: added addr: 173.255.209.126:44806
addrman: added addr: 172.104.177.177:44806
addrman: added addr: 139.162.183.168:44806
addrman: added addr: 74.207.247.120:44806
addrman: added addr: 45.79.134.225:44806
pool: could not add seed: aonetsezqp4m52w4jpfq2gv3dggy2wqfwqtkfjyttgdidbvhgp5as@165.22.151.242
pool: pool opened (size=8)
...
```
