### PR TITLE
respond with servfail if bogus

### DIFF
--- a/src/rs.c
+++ b/src/rs.c
@@ -437,8 +437,10 @@ hsk_rs_respond(
   hsk_rs_log(ns, "  secure: %d\n", result->secure);
   hsk_rs_log(ns, "  bogus: %d\n", result->bogus);
 
-  if (result->why_bogus)
+  if (result->bogus) {
     hsk_rs_log(ns, "  why_bogus: %s\n", result->why_bogus);
+    goto fail;
+  }  
 
   uint8_t *data = result->answer_packet;
   size_t data_len = result->answer_len;
@@ -455,7 +457,7 @@ hsk_rs_respond(
   msg->code = result->rcode;
   msg->flags |= HSK_DNS_RA;
 
-  if (result->secure && !result->bogus)
+  if (result->secure)
     msg->flags |= HSK_DNS_AD;
 
   // Strip out non-answer sections.


### PR DESCRIPTION
When validating DNSSEC, the resolver should return SERVFAIL if DNSSEC validation fails (bogus = true) 

example:

`dig @1.1.1.1 dnssec-failed.org a`

will return SERVFAIL

hnsd only omits the ad flag from the response which makes downgrade attacks possible.

~~Note: hnsd also considers handshake tlds without a DS RR bogus (they are not secure but they are also not bogus). This should also be fixed because this PR will break handshake tlds that don't use DNSSEC.~~

Fixed by adding an NSEC record to prove that a DS doesn't exist which allows unbound to treat it as unsigned instead of bogus.

