### PR TITLE
pkg: bump version to 1.0.0 and remove mainnet warning

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -23,7 +23,7 @@ libhsk_la_LIBADD = $(top_builddir)/uv/libuv.la   \
                    $(LIB_WINBCRYPT)
 
 libhsk_la_CFLAGS = -DHSK_BUILD @CFLAGS@
-libhsk_la_LDFLAGS = -no-undefined -version-info 0:0:0
+libhsk_la_LDFLAGS = -no-undefined -version-info 1:0:0
 libhsk_la_SOURCES = src/addr.c                   \
                     src/addrmgr.c                \
                     src/aead.c                   \

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-:warning: Currently, `hnsd` is not compatible with the latest, Handshake
-p2p network protocol. We are exploring a potential rewrite of the entire
-codebase. Please watch this repo for development updates.
-
 # hnsd
 
 SPV resolver daemon for the [Handshake][hns] network. Written in C for

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 AC_PREREQ([2.57])
-AC_INIT([hnsd], [0.0.0], [chjj@handshake.org])
+AC_INIT([hnsd], [1.0.0], [chjj@handshake.org])
 AC_CONFIG_MACRO_DIR([m4])
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 

--- a/man/hnsd.1
+++ b/man/hnsd.1
@@ -1,5 +1,5 @@
 .ds q \N'34'
-.TH hnsd 1 "2018-08-01" "v0.0.0" "hnsd"
+.TH hnsd 1 "2020-09-24" "v1.0.0" "hnsd"
 
 .SH NAME
 hnsd \- SPV resolver for the Handshake network

--- a/src/constants.h
+++ b/src/constants.h
@@ -13,7 +13,7 @@
 #endif
 
 #define HSK_MAX_MESSAGE (8 * 1000 * 1000)
-#define HSK_USER_AGENT "/hnsd:0.0.0/"
+#define HSK_USER_AGENT "/hnsd:1.0.0/"
 #define HSK_PROTO_VERSION 1
 #define HSK_SERVICES 0
 #define HSK_MAX_DATA_SIZE 668

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -107,7 +107,7 @@ static void
 help(int r) {
   fprintf(stderr,
     "\n"
-    "hnsd 0.0.0\n"
+    "hnsd 1.0.0\n"
     "  Copyright (c) 2018, Christopher Jeffrey <chjj@handshake.org>\n"
     "\n"
     "Usage: hnsd [options]\n"


### PR DESCRIPTION
I had to a search-and-replace for this, probably could be automated for future versions.
Hoping I didn't miss anything!
🚀  very excited to release!