### PR TITLE
fixed implicit declaration by importing elligator.h to ec.h

### DIFF
--- a/src/ec.h
+++ b/src/ec.h
@@ -8,6 +8,8 @@
 
 #include "hash.h"
 #include "secp256k1.h"
+#include "secp256k1/elligator.h"
+
 
 typedef hsk_secp256k1_context hsk_ec_t;
 


### PR DESCRIPTION
An implicit declaration was blocking builds on macs with clang 12 and creatinng warnings on all platforms.  

This resolves that issue by importing elligator.h in ec.h  ﻿
