### PR TITLE
makefile: install hnsd

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -59,8 +59,7 @@ libhsk_la_SOURCES = src/addr.c                   \
 EXTRA_DIST = README.md \
              LICENSE
 
-PROGS = hnsd
-noinst_PROGRAMS = $(PROGS)
+bin_PROGRAMS = hnsd
 
 hnsd_SOURCES = src/cache.c  \
                src/daemon.c \

--- a/README.md
+++ b/README.md
@@ -120,6 +120,12 @@ $ cd hnsd
 $ ./autogen.sh && ./configure && make
 ```
 
+### Optional
+
+``` sh
+$ sudo make install
+```
+
 ## Setup
 
 Currently, hnsd will setup a recursive name server listening locally. If


### PR DESCRIPTION
This change allows one to do `sudo make install` and get the `hnsd` binary in a standard installation directory.

`noinst_PROGRAMS` seems like it was explicitly disabled but I don't know the reasoning.

This change will allow package managers like AUR to install the binary  (currently it does not)

https://aur.archlinux.org/packages/hnsd-git/

Tagging @Thann who maintains the AUR package.