### PR TITLE
chain: add header store

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -32,6 +32,7 @@ libhsk_la_SOURCES = src/addr.c                   \
                     src/bn.c                     \
                     src/brontide.c               \
                     src/chacha20/chacha20.c      \
+                    src/store.c                  \
                     src/chain.c                  \
                     src/dns.c                    \
                     src/dnssec.c                 \

--- a/src/chain.c
+++ b/src/chain.c
@@ -112,6 +112,8 @@ hsk_chain_init_genesis(hsk_chain_t *chain) {
   chain->tip = tip;
   chain->genesis = tip;
 
+  hsk_store_write(chain->store, data, 236);
+
   hsk_chain_maybe_sync(chain);
 
   return HSK_SUCCESS;

--- a/src/chain.c
+++ b/src/chain.c
@@ -730,6 +730,7 @@ hsk_chain_insert(
   uint8_t *data = malloc(236);
   hsk_header_encode(hdr, data);
   hsk_store_write(chain->store, data, sizeof(data));
+  free(data);
 
   return HSK_SUCCESS;
 }

--- a/src/chain.c
+++ b/src/chain.c
@@ -729,7 +729,7 @@ hsk_chain_insert(
 
   uint8_t *data = malloc(236);
   hsk_header_encode(hdr, data);
-  hsk_store_write(chain->store, data, sizeof(data));
+  hsk_store_write(chain->store, data, 236);
   free(data);
 
   return HSK_SUCCESS;

--- a/src/chain.h
+++ b/src/chain.h
@@ -8,12 +8,14 @@
 #include "map.h"
 #include "header.h"
 #include "timedata.h"
+#include "store.h"
 
 /*
  * Types
  */
 
 typedef struct hsk_chain_s {
+  uv_loop_t *loop;
   int64_t height;
   hsk_header_t *tip;
   hsk_header_t *genesis;
@@ -23,6 +25,7 @@ typedef struct hsk_chain_s {
   hsk_map_t heights;
   hsk_map_t orphans;
   hsk_map_t prevs;
+  hsk_store_t *store;
 } hsk_chain_t;
 
 /*
@@ -30,13 +33,13 @@ typedef struct hsk_chain_s {
  */
 
 int
-hsk_chain_init(hsk_chain_t *chain, const hsk_timedata_t *td);
+hsk_chain_init(hsk_chain_t *chain, const hsk_timedata_t *td, const uv_loop_t *loop);
 
 void
 hsk_chain_uninit(hsk_chain_t *chain);
 
 hsk_chain_t *
-hsk_chain_alloc(const hsk_timedata_t *td);
+hsk_chain_alloc(const hsk_timedata_t *td, const uv_loop_t *loop);
 
 void
 hsk_chain_free(hsk_chain_t *chain);

--- a/src/header.c
+++ b/src/header.c
@@ -48,7 +48,8 @@ hsk_header_init(hsk_header_t *hdr) {
 hsk_header_t *
 hsk_header_alloc(void) {
   hsk_header_t *hdr = malloc(sizeof(hsk_header_t));
-  hsk_header_init(hdr);
+  if (hdr)
+    hsk_header_init(hdr);
   return hdr;
 }
 

--- a/src/pool.c
+++ b/src/pool.c
@@ -783,12 +783,6 @@ hsk_pool_timer(hsk_pool_t *pool) {
   }
 
   hsk_pool_refill(pool);
-
-  // FIXME: testing header store - read tip
-  hsk_header_t *hdr = hsk_header_alloc();
-  hsk_store_read(pool->chain.store, pool->chain.tip->height, hdr);
-  printf("pool->chain.tip->height; hdr->height: %d; %d\n", pool->chain.tip->height, hdr->height);
-  free(hdr);
 }
 
 /*

--- a/src/pool.c
+++ b/src/pool.c
@@ -16,6 +16,7 @@
 #include "bn.h"
 #include "brontide.h"
 #include "chain.h"
+#include "store.h"
 #include "constants.h"
 #include "ec.h"
 #include "error.h"
@@ -160,7 +161,7 @@ hsk_pool_init(hsk_pool_t *pool, const uv_loop_t *loop) {
   pool->ec = ec;
   pool->key = &pool->key_[0];
   hsk_timedata_init(&pool->td);
-  hsk_chain_init(&pool->chain, &pool->td);
+  hsk_chain_init(&pool->chain, &pool->td, pool->loop);
   hsk_addrman_init(&pool->am, &pool->td);
   pool->timer = NULL;
   pool->peer_id = 0;

--- a/src/pool.c
+++ b/src/pool.c
@@ -17,6 +17,7 @@
 #include "brontide.h"
 #include "chain.h"
 #include "store.h"
+#include "store.h"
 #include "constants.h"
 #include "ec.h"
 #include "error.h"
@@ -782,6 +783,12 @@ hsk_pool_timer(hsk_pool_t *pool) {
   }
 
   hsk_pool_refill(pool);
+
+  // FIXME: testing header store - read tip
+  hsk_header_t *hdr = hsk_header_alloc();
+  hsk_store_read(pool->chain.store, pool->chain.tip->height, hdr);
+  printf("pool->chain.tip->height; hdr->height: %d; %d\n", pool->chain.tip->height, hdr->height);
+  free(hdr);
 }
 
 /*

--- a/src/store.c
+++ b/src/store.c
@@ -49,7 +49,7 @@ hsk_store_open(hsk_store_t *store) {
     return HSK_EFAILURE;
   }
 
-   store->size = 65536 * sizeof(hsk_store_t) + 1;
+   store->size = 65536 * 236 + 1;
 
   if (lseek(store->fd, store->size-1, SEEK_SET) == -1)
   {

--- a/src/store.c
+++ b/src/store.c
@@ -97,7 +97,7 @@ int
 hsk_store_read(hsk_store_t *store, int height, hsk_header_t *header) {
   uint8_t *data = malloc(236);
   for (size_t i = 0; i < 236; i++) {
-    data[i] = store->map[i*height];
+    data[i] = store->map[i + height*236];
   }
   hsk_header_decode(data, 236, header);
   free(data);

--- a/src/store.c
+++ b/src/store.c
@@ -94,6 +94,16 @@ hsk_store_write(hsk_store_t *store, uint8_t *data, size_t len) {
 }
 
 int
+hsk_store_read(hsk_store_t *store, int height, hsk_header_t *header) {
+  uint8_t *data = malloc(236);
+  for (size_t i = 0; i < 236; i++) {
+    data[i] = store->map[i*height];
+  }
+  hsk_header_decode(data, 236, header);
+  free(data);
+}
+
+int
 hsk_store_sync(hsk_store_t *store) {
   if(msync(store->map, store->size, MS_SYNC) == -1)
   {

--- a/src/store.c
+++ b/src/store.c
@@ -87,10 +87,10 @@ hsk_store_open(hsk_store_t *store) {
 
 int
 hsk_store_write(hsk_store_t *store, uint8_t *data, size_t len) {
-  for (size_t i = store->pos; i < len; i++) {
-    store->map[i] = data[i-store->pos];
+  for (size_t i = 0; i < len; i++) {
+    store->map[i+store->pos] = data[i];
   }
-  store->pos = len;
+  store->pos += len;
 }
 
 int

--- a/src/store.c
+++ b/src/store.c
@@ -1,0 +1,138 @@
+#include <sys/mman.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include "utils.h"
+#include "error.h"
+#include "header.h"
+#include "store.h"
+
+int
+hsk_store_init(hsk_store_t *store, const uv_loop_t *loop) {
+  store->loop = (uv_loop_t *)loop;
+  store->fd = -1;
+  store->map = NULL;
+  store->location = "/tmp/hnsd.bin";
+  store->headers = malloc(sizeof(hsk_store_t));
+  store->timer = NULL;
+}
+
+int hsk_store_uninit(hsk_store_t *store) {
+  store->map = NULL;
+  store->location = NULL;
+  store->headers = NULL;
+  if (munmap(store->map, store->size) == -1)
+  {
+    close(store->fd);
+    return HSK_EFAILURE;
+  }
+}
+
+static void
+after_timer(uv_timer_t *timer) {
+  hsk_store_t *store = (hsk_store_t *)timer->data;
+  assert(store);
+  hsk_store_timer(store);
+}
+
+static void
+hsk_store_timer(hsk_store_t *store) {
+  hsk_store_sync(store);
+}
+
+int
+hsk_store_open(hsk_store_t *store) {
+  store->fd = open(store->location, O_RDWR | O_CREAT | O_TRUNC, (mode_t)0600);
+
+  if (store->fd == -1)
+  {
+    return HSK_EFAILURE;
+  }
+
+   store->size = 65536 * sizeof(hsk_store_t) + 1;
+
+  if (lseek(store->fd, store->size-1, SEEK_SET) == -1)
+  {
+    close(store->fd);
+    return HSK_EFAILURE;
+  }
+
+  if (write(store->fd, "", 1) == -1)
+  {
+    close(store->fd);
+    return HSK_EFAILURE;
+  }
+
+  store->map = mmap(0, store->size, PROT_READ | PROT_WRITE, MAP_SHARED, store->fd, 0);
+  if (store->map == MAP_FAILED)
+  {
+    close(store->fd);
+    return HSK_EFAILURE;
+  }
+
+  store->timer = malloc(sizeof(uv_timer_t));
+  if (!store->timer)
+    return HSK_ENOMEM;
+
+  store->timer->data = (void *)store;
+
+  if (uv_timer_init(store->loop, store->timer) != 0)
+    return HSK_EFAILURE;
+
+  if (uv_timer_start(store->timer, after_timer, 3000, 3000) != 0)
+    return HSK_EFAILURE;
+
+  return HSK_SUCCESS;
+}
+
+int
+hsk_store_write(hsk_store_t *store, uint8_t *data, size_t len) {
+  for (size_t i = store->pos; i < len; i++) {
+    store->map[i] = data[i-store->pos];
+  }
+  store->pos = len;
+}
+
+int
+hsk_store_sync(hsk_store_t *store) {
+  if(msync(store->map, store->size, MS_SYNC) == -1)
+  {
+    close(store->map);
+    return HSK_EFAILURE;
+  }
+}
+
+int
+hsk_store_close(hsk_store_t *store) {
+  close(store->fd);
+
+  if (uv_timer_stop(store->timer) != 0)
+    return HSK_EFAILURE;
+
+  hsk_uv_close_free((uv_handle_t*)store->timer);
+  return HSK_SUCCESS;
+}
+
+void
+hsk_store_free(hsk_store_t *store) {
+  if (!store)
+    return;
+
+  hsk_store_uninit(store);
+  free(store);
+}
+
+hsk_store_t *
+hsk_store_alloc(const uv_loop_t *loop) {
+  hsk_store_t *store = malloc(sizeof(hsk_store_t));
+
+  if (!store)
+    return NULL;
+
+  if (hsk_store_init(store, loop) != HSK_SUCCESS) {
+    hsk_store_free(store);
+    return NULL;
+  }
+
+  return store;
+}

--- a/src/store.h
+++ b/src/store.h
@@ -10,6 +10,7 @@
 
 typedef struct hsk_store_s {
   uv_loop_t *loop;
+  bool init;
   int fd;
   size_t size;
   uint8_t *map;

--- a/src/store.h
+++ b/src/store.h
@@ -1,0 +1,48 @@
+#ifndef _HSK_STORE_H
+#define _HSK_STORE_H
+
+#include "uv.h"
+#include "header.h"
+
+/*
+ * Types
+ */
+
+typedef struct hsk_store_s {
+  uv_loop_t *loop;
+  int fd;
+  size_t size;
+  uint8_t *map;
+  size_t pos;
+  char *location;
+  hsk_header_t *headers ;
+  uv_timer_t *timer;
+} hsk_store_t;
+
+
+int
+hsk_store_init(hsk_store_t *store, const uv_loop_t *loop);
+
+int hsk_store_uninit(hsk_store_t *store);
+
+static void
+hsk_store_timer(hsk_store_t *store);
+
+int
+hsk_store_open(hsk_store_t *store);
+
+int
+hsk_store_write(hsk_store_t *store, uint8_t *data, size_t len);
+
+int
+hsk_store_sync(hsk_store_t *store);
+
+int
+hsk_store_close(hsk_store_t *store);
+
+void
+hsk_store_free(hsk_store_t *store);
+
+hsk_store_t *
+hsk_store_alloc();
+#endif

--- a/src/store.h
+++ b/src/store.h
@@ -35,6 +35,9 @@ int
 hsk_store_write(hsk_store_t *store, uint8_t *data, size_t len);
 
 int
+hsk_store_read(hsk_store_t *store, int height, hsk_header_t *header);
+
+int
 hsk_store_sync(hsk_store_t *store);
 
 int


### PR DESCRIPTION
This PR adds a persistent header store to the chain. The headers are read from the disk on startup, and processed as usual. This should be fairly safe as chain work is validated every time. The store is backed by a mmaped file (currently written to `/tmp/hnsd.bin`). The format is pretty straightforward, it's just the header encoded to bytes and written to disk.

Some work remaining here:

* Write number of headers written somewhere (first byte?) so that one can allocate memory accordingly.
* Page the mmap file after first 65536 headers are processed (currently this is hardcoded and will break after block 65536).
* Multi-OS testing (mmap doesn't work on windows so maybe switch to normal file).