### PR TITLE
Allow configurable --upstream recursive resolver for non-HNS queries

### DIFF
--- a/src/daemon.c
+++ b/src/daemon.c
@@ -471,7 +471,7 @@ hsk_daemon_init(hsk_daemon_t *daemon, uv_loop_t *loop, hsk_options_t *opt) {
     }
   }
 
-  daemon->rs = hsk_rs_alloc(loop, opt->ns_host);
+  daemon->rs = hsk_rs_alloc(loop, opt->ns_host, opt->upstream);
 
   if (!daemon->rs) {
     fprintf(stderr, "failed initializing rns\n");

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -36,6 +36,8 @@ typedef struct hsk_options_s {
   uint8_t *identity_key;
   char *seeds;
   int pool_size;
+  char *upstream;
+  
 } hsk_options_t;
 
 static void
@@ -52,6 +54,7 @@ hsk_options_init(hsk_options_t *opt) {
   opt->identity_key = NULL;
   opt->seeds = NULL;
   opt->pool_size = HSK_POOL_SIZE;
+  opt->upstream = NULL;
 }
 
 static void
@@ -141,6 +144,11 @@ help(int r) {
     "  -l, --log-file <filename>\n"
     "    Redirect output to a log file.\n"
     "\n"
+    "  -t, --upstream <ip[:port]>\n"
+    "    IP address and port to forward queries that fail HNS lookup.\n"
+    "    Example:\n"
+    "      -t 1.1.1.1\n"
+    "\n"
 #ifndef _WIN32
     "  -d, --daemon\n"
     "    Fork and background the process.\n"
@@ -156,7 +164,7 @@ help(int r) {
 
 static void
 parse_arg(int argc, char **argv, hsk_options_t *opt) {
-  const static char *optstring = "c:n:r:i:u:p:k:s:l:h"
+  const static char *optstring = "c:n:r:i:u:p:k:s:l:t:h"
 #ifndef _WIN32
     "d"
 #endif
@@ -172,6 +180,7 @@ parse_arg(int argc, char **argv, hsk_options_t *opt) {
     { "identity-key", required_argument, NULL, 'k' },
     { "seeds", required_argument, NULL, 's' },
     { "log-file", required_argument, NULL, 'l' },
+    { "upstream", required_argument, NULL, 't' },
 #ifndef _WIN32
     { "daemon", no_argument, NULL, 'd' },
 #endif
@@ -307,6 +316,18 @@ parse_arg(int argc, char **argv, hsk_options_t *opt) {
         break;
       }
 
+      case 't': {
+        if (!optarg || strlen(optarg) == 0)
+          return help(1);
+
+        if (opt->upstream)
+          free(opt->upstream);
+
+        opt->upstream = strdup(optarg);
+
+        break;
+      }
+
 #ifndef _WIN32
       case 'd': {
         background = true;
@@ -428,7 +449,7 @@ hsk_daemon_init(hsk_daemon_t *daemon, uv_loop_t *loop, hsk_options_t *opt) {
     goto fail;
   }
 
-  daemon->ns = hsk_ns_alloc(loop, daemon->pool);
+  daemon->ns = hsk_ns_alloc(loop, daemon->pool, (bool)opt->upstream);
 
   if (!daemon->ns) {
     fprintf(stderr, "failed initializing ns\n");

--- a/src/error.c
+++ b/src/error.c
@@ -38,6 +38,7 @@ static const char *errstrs[] = {
   "EACTTHREE",
   "EBADSIZE",
   "EBADTAG",
+  "EREFUSED",
   "EUNKNOWN"
 };
 

--- a/src/error.h
+++ b/src/error.h
@@ -45,8 +45,11 @@
 #define HSK_EBADSIZE 30
 #define HSK_EBADTAG 31
 
+// DNS
+#define HSK_EREFUSED 32
+
 // Max
-#define HSK_MAXERROR 32
+#define HSK_MAXERROR 33
 
 const char *
 hsk_strerror(int code);

--- a/src/ns.h
+++ b/src/ns.h
@@ -33,6 +33,7 @@ typedef struct {
   uint8_t pubkey[33];
   uint8_t read_buffer[HSK_UDP_BUFFER];
   bool receiving;
+  bool upstream;
 } hsk_ns_t;
 
 /*
@@ -40,7 +41,12 @@ typedef struct {
  */
 
 int
-hsk_ns_init(hsk_ns_t *ns, const uv_loop_t *loop, const hsk_pool_t *pool);
+hsk_ns_init(
+  hsk_ns_t *ns,
+  const uv_loop_t *loop,
+  const hsk_pool_t *pool,
+  const bool upstream
+);
 
 void
 hsk_ns_uninit(hsk_ns_t *ns);
@@ -58,7 +64,11 @@ int
 hsk_ns_close(hsk_ns_t *ns);
 
 hsk_ns_t *
-hsk_ns_alloc(const uv_loop_t *loop, const hsk_pool_t *pool);
+hsk_ns_alloc(
+  const uv_loop_t *loop,
+  const hsk_pool_t *pool,
+  const bool upstream
+);
 
 void
 hsk_ns_free(hsk_ns_t *ns);

--- a/src/resource.c
+++ b/src/resource.c
@@ -1113,6 +1113,18 @@ hsk_resource_to_notimp(void) {
   return msg;
 }
 
+hsk_dns_msg_t *
+hsk_resource_to_refused(void) {
+  hsk_dns_msg_t *msg = hsk_dns_msg_alloc();
+
+  if (!msg)
+    return NULL;
+
+  msg->code = HSK_DNS_REFUSED;
+
+  return msg;
+}
+
 /*
  * Helpers
  */

--- a/src/resource.h
+++ b/src/resource.h
@@ -91,6 +91,9 @@ hsk_resource_to_servfail(void);
 hsk_dns_msg_t *
 hsk_resource_to_notimp(void);
 
+hsk_dns_msg_t *
+hsk_resource_to_refused(void);
+
 bool
 hsk_resource_is_ptr(const char *name);
 

--- a/src/rs.h
+++ b/src/rs.h
@@ -31,6 +31,9 @@ typedef struct {
   bool receiving;
   void *stop_data;
   void (*stop_callback)(void *);
+  char *upstream;
+  struct ub_ctx *fallback;
+  hsk_rs_worker_t *fallback_worker;
 } hsk_rs_t;
 
 /*
@@ -38,7 +41,12 @@ typedef struct {
  */
 
 int
-hsk_rs_init(hsk_rs_t *ns, const uv_loop_t *loop, const struct sockaddr *stub);
+hsk_rs_init(
+  hsk_rs_t *ns,
+  const uv_loop_t *loop,
+  const struct sockaddr *stub,
+  const char *upstream
+);
 
 void
 hsk_rs_uninit(hsk_rs_t *ns);
@@ -58,7 +66,11 @@ int
 hsk_rs_close(hsk_rs_t *ns, void *stop_data, void (*stop_callback)(void *));
 
 hsk_rs_t *
-hsk_rs_alloc(const uv_loop_t *loop, const struct sockaddr *stub);
+hsk_rs_alloc(
+  const uv_loop_t *loop,
+  const struct sockaddr *stub,
+  const char *upstream
+);
 
 void
 hsk_rs_free(hsk_rs_t *ns);


### PR DESCRIPTION
Closes https://github.com/handshake-org/hnsd/issues/53

This PR allows the user to pass the address of an  "upstream" recursive resolver to hnsd, which is used when a query fails to resolve from HNS root zone _instead of_ the typical built-in "ICANN fallback" implemented in the root nameserver itself.

Example usages:

`hnsd --upstream 1.1.1.1`

`hnsd -t 10.0.1.200:5350`

The main changes to hnsd when `--upstream` is passed in:

- When the root nameserver (`ns`) gets a proof of nonexistence from the HNS network, instead of looking up the name in the hard-coded ICANN root zone file and resolving there, the `ns` returns an error: `REFUSED`

- On launch, the recursive resolver (`rs`) normally spawns an unbound context and configures the `ns` server as a stub server for the `"."` zone. This still happens - but IN ADDITION, a _second_ unbound context is spawned (called `fallback`) configured with [`ub_ctx_set_fwd()`](https://nlnetlabs.nl/documentation/unbound/libunbound/) meaning ALL queries are forwarded to an upstream recursive resolver.

- All responses from the primary `rs` unbound instance are inspected after they are resolved. If the response from unbound is `SERVFAIL`, the request is passed to the `fallback` instance of unbound.

Observe in the logs: (using `hnsd -t 1.1.1.1`)

```
pool: sending proof request for: com.
chain (274): using safe height of 270 for resolution
peer 0 (127.0.0.1:46806): sending proof request for: com.
peer 0 (127.0.0.1:46806): received proof: f84185260b0e865f7bafa35aeeed8bb1ffdaaa91ce624092a9b20a27511a161e
peer 0 (127.0.0.1:46806): received proof for: com
ns: forwarding to upstream resolver: com
ns: resolve response error: EREFUSED
ns: sending refused (33813)
ns: query
ns:   id=39895
ns:   labels=2
ns:   name=google.com.
ns:   type=1
ns:   class=1
ns:   edns=1
ns:   dnssec=1
ns:   tld=com
ns:   addr=127.0.0.1:52369
...
rs: received answer for: google.com.
rs: redirecting lookup to fallback for: google.com.
rs_worker: request 1: google.com.
rs: received answer for: google.com.
rs:   rcode: 0
rs:   havedata: 1
rs:   nxdomain: 0
rs:   secure: 0
rs:   bogus: 0
```

## Disclaimer

I think this PR is a bit smelly. Creating an entire second recursive resolver seems like a bit much, but I couldn't think of any other way to do this, because unbound requires all this configuration up front before opening (like setting a stub zone). So with unbound, either all requests get forwarded, or all requests get sent to the specified root zone server. I may try to experiment with other approaches using the same unbound instance but the configuration options are limiting.

It also means there is a second unbound worker and worker thread. This made closing the program cleanly tricky because of funny async stuff in the original design which never intended for there to be more than one unbound thread.

Finally, the "trick" isn't perfect either. I'm using the `REFUSED` error message from root `ns` to unbound to trigger the fallback resolution, but by the time unbound returns the response, its been glossed over with a simple `SERVFAIL`. This could mean that ANY error from `ns` being interpreted as `SERVFAIL` by unbound will lead to the fallback resolution. This can probably be switched to `NXDOMAIN` since the root `ns` isn't checking the ICANN zone at all in this mode.



