### PR TITLE
version: set no_relay true and ignore tx invs

### DIFF
--- a/src/msg.c
+++ b/src/msg.c
@@ -414,7 +414,7 @@ hsk_msg_init(hsk_msg_t *msg) {
       m->nonce = 0;
       memset(m->agent, 0, 256);
       m->height = 0;
-      m->no_relay = false;
+      m->no_relay = true;
       break;
     }
     case HSK_MSG_VERACK: {


### PR DESCRIPTION
This addresses the issue in #56 with the hnsd receiving lots of "unknown command" messages which turn out to be transaction inventory messages. We disable transaction relay (using version flag) and cut down on these since we won't be relaying them anyway.