### PR TITLE
pool: check for errors in after_read before using the buffer

### DIFF
--- a/src/pool.c
+++ b/src/pool.c
@@ -1802,7 +1802,14 @@ after_read(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf) {
 
   if (!peer)
     return;
-
+  
+  if (nread < 0) {
+    if (nread != UV_EOF)
+      hsk_peer_log(peer, "read error: %s\n", uv_strerror(nread));
+    hsk_peer_destroy(peer);
+    return;
+  }
+  
   if (peer->brontide != NULL) {
     int r = hsk_brontide_on_read(
         peer->brontide,
@@ -1820,13 +1827,6 @@ after_read(uv_stream_t *stream, ssize_t nread, const uv_buf_t *buf) {
         (uint8_t *)buf->base,
         (size_t)nread
         );
-  }
-
-  if (nread < 0) {
-    if (nread != UV_EOF)
-      hsk_peer_log(peer, "read error: %s\n", uv_strerror(nread));
-    hsk_peer_destroy(peer);
-    return;
   }
 }
 


### PR DESCRIPTION
This PR fixes a frequent crash on windows whenever a connection resets with error -4077. This crash should technically happen on other OSs but I've only noticed it frequently on windows.

```
Thread 1 received signal SIGSEGV, Segmentation fault.
0x00007ffb1ceb43cf in msvcrt!memmove () from C:\Windows\System32\msvcrt.dll
(gdb) bt
#0  0x00007ffb1ceb43cf in msvcrt!memmove ()
   from C:\Windows\System32\msvcrt.dll
#1  0x00007ff6bf897801 in hsk_peer_on_read (peer=0x1b68af72ee0,
    data=<optimized out>, data_len=<optimized out>) at src/pool.c:1603
#2  0x00007ff6bf898206 in hsk_peer_on_read (data_len=18446744073709547539,
    data=<optimized out>, peer=0x1b68af72ee0) at src/pool.c:1595
#3  after_read (stream=<optimized out>, nread=-4077, buf=<optimized out>)
    at src/pool.c:1818
#4  0x00007ff6bf8d0f51 in uv_process_tcp_read_req (
    loop=loop@entry=0x7ff6bf972120 <default_loop_struct>,
    handle=0x1b68af72ef8, req=req@entry=0x1b68af72f78) at src/win/tcp.c:976
#5  0x00007ff6bf8be64b in uv_process_reqs (
    loop=0x7ff6bf972120 <default_loop_struct>) at src/win/req-inl.h:159
#6  uv_run (loop=0x7ff6bf972120 <default_loop_struct>, mode=UV_RUN_DEFAULT)
    at src/win/core.c:503
#7  0x00007ff6bf883367 in main (argc=1, argv=0x1b688541970)
    at src/daemon.c:621
```

the `after_read` function [here](https://github.com/handshake-org/hnsd/blob/master/src/pool.c#L1800) is getting called with nread=-4077 a negative nread value means [an error]( http://docs.libuv.org/en/v1.x/stream.html#c.uv_read_cb) in this case it's [ECONNRESET](https://github.com/handshake-org/hnsd/blob/master/uv/include/uv-errno.h#L134)


~~Also, on error hnsd only destroys the peer but it doesn't free data in the buffer like in this [example](https://github.com/handshake-org/hnsd/blob/master/uv/test/dns-server.c#L243)  so it could leak a bit of memory whenever an error occurs and the buffer is not empty~~


```
The callee is responsible for freeing the buffer, libuv does not reuse it. The buffer may be a null buffer 
(where buf->base == NULL and buf->len == 0) on error.
```

