### PR TITLE
ns/resource: fix SYNTH records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ m4/ltsugar.m4
 m4/ltversion.m4
 m4/lt~obsolete.m4
 src/stamp-h1
+test_hnsd

--- a/Makefile.am
+++ b/Makefile.am
@@ -75,5 +75,12 @@ hnsd_LDFLAGS = -static
 hnsd_CFLAGS = -DHSK_BUILD $(INC_UNBOUND) $(AM_CFLAGS)
 hnsd_CPPFLAGS = $(AM_CPPFLAGS)
 
+noinst_PROGRAMS = test_hnsd
+
+test_hnsd_SOURCES = test/hnsd-test.c
+
+test_hnsd_LDADD = $(LIB_UNBOUND)             \
+                  $(top_builddir)/libhsk.la
+
 # pkgconfigdir = $(libdir)/pkgconfig
 # pkgconfig_DATA = @PACKAGE_NAME@.pc

--- a/README.md
+++ b/README.md
@@ -328,6 +328,12 @@ $ hnsd [options]
   Help message.
 ```
 
+## Testing
+
+The `make` command will output two binaries into the root directory: `hnsd`
+and `test_hnsd`, which is compiled from unit tests in the `test/` directory.
+Run the tests with `./test_hnsd`.
+
 ## License
 
 - Copyright (c) 2018, Christopher Jeffrey (MIT License).

--- a/src/ns.c
+++ b/src/ns.c
@@ -337,12 +337,6 @@ hsk_ns_onrecv(
     && req->labels == 2
     && req->name[0] == '_'
   ) {
-    uint8_t ip[16];
-    uint16_t family;
-
-    char synth[HSK_DNS_MAX_LABEL + 1];
-    hsk_dns_label_from(req->name, -2, synth);
-
     msg = hsk_dns_msg_alloc();
 
     if (!msg)
@@ -351,6 +345,11 @@ hsk_ns_onrecv(
     hsk_dns_rrs_t *an = &msg->an;
     hsk_dns_rrs_t *rrns = &msg->ns;
     hsk_dns_rrs_t *ar = &msg->ar;
+
+    uint8_t ip[16];
+    uint16_t family;
+    char synth[HSK_DNS_MAX_LABEL + 1];
+    hsk_dns_label_from(req->name, -2, synth);
 
     if (pointer_to_ip(synth, ip, &family)) {
       bool match = false;

--- a/src/ns.c
+++ b/src/ns.c
@@ -332,12 +332,21 @@ hsk_ns_onrecv(
   // with a name that encodes an IP address: _[base32]._synth.
   // The synth name then resolves to an A/AAAA record that is derived
   // by decoding the name itself (it does not have to be looked up).
-  if (strcmp(req->tld, "_synth") && req->labels == 2 && req->name[0] == '_') {
+  if (
+    strcmp(req->tld, "_synth") == 0
+    && req->labels == 2
+    && req->name[0] == '_'
+  ) {
     uint8_t ip[16];
     uint16_t family;
 
     char synth[HSK_DNS_MAX_LABEL + 1];
     hsk_dns_label_from(req->name, -2, synth);
+
+    msg = hsk_dns_msg_alloc();
+
+    if (!msg)
+      goto fail;
 
     hsk_dns_rrs_t *an = &msg->an;
     hsk_dns_rrs_t *rrns = &msg->ns;

--- a/src/ns.c
+++ b/src/ns.c
@@ -332,12 +332,10 @@ hsk_ns_onrecv(
   // with a name that encodes an IP address: _[base32]._synth.
   // The synth name then resolves to an A/AAAA record that is derived
   // by decoding the name itself (it does not have to be looked up).
-  if (
-    strcmp(req->tld, "_synth") == 0
-    && req->labels == 2
-    && req->name[0] == '_'
-  ) {
+  bool synth = false;
+  if (strcmp(req->tld, "_synth") == 0 && req->labels <= 2) {
     msg = hsk_dns_msg_alloc();
+    synth = true;
 
     if (!msg)
       goto fail;
@@ -351,6 +349,13 @@ hsk_ns_onrecv(
     char synth[HSK_DNS_MAX_LABEL + 1];
     hsk_dns_label_from(req->name, -2, synth);
 
+    if (req->labels == 1) {
+      hsk_resource_to_empty(req->tld, NULL, 0, rrns);
+      hsk_dnssec_sign_zsk(rrns, HSK_DNS_NSEC);
+      hsk_resource_root_to_soa(rrns);
+      hsk_dnssec_sign_zsk(rrns, HSK_DNS_SOA);
+    }
+  
     if (pointer_to_ip(synth, ip, &family)) {
       bool match = false;
 
@@ -468,7 +473,8 @@ hsk_ns_onrecv(
     goto fail;
   }
 
-  hsk_cache_insert(&ns->cache, req, msg);
+  if (!synth)
+    hsk_cache_insert(&ns->cache, req, msg);
 
   if (!hsk_dns_msg_finalize(&msg, req, ns->ec, ns->key, &wire, &wire_len)) {
     hsk_ns_log(ns, "could not reply\n");

--- a/src/resource.c
+++ b/src/resource.c
@@ -30,15 +30,6 @@ static const uint8_t hsk_type_map[] = {
 static void
 to_fqdn(char *name);
 
-static void
-ip_size(const uint8_t *ip, size_t *s, size_t *l);
-
-static size_t
-ip_write(const uint8_t *ip, uint8_t *data);
-
-static bool
-ip_read(const uint8_t *data, uint8_t *ip);
-
 /*
  * Resource serialization version 0
  * Record types: read
@@ -511,9 +502,9 @@ hsk_resource_to_ns(
       char b32[29];
 
       if (c->type == HSK_SYNTH4)
-        ip_to_b32(c->inet4, b32, 4);
+        hsk_base32_encode_hex(c->inet4, 4, b32, false);
       else
-        ip_to_b32(c->inet6, b32, 16);
+        hsk_base32_encode_hex(c->inet6, 16, b32, false);
 
       // Magic pseudo-TLD can also be directly resolved by hnsd
       sprintf(nsname, "_%s._synth.", b32);
@@ -648,12 +639,26 @@ hsk_resource_to_glue(
     hsk_record_t *c = res->records[i];
 
     switch (c->type) {
-      case HSK_GLUE4:
+      case HSK_GLUE4: {
         if (!hsk_dns_is_subdomain(tld, c->name))
-          continue;
+          break;
+
+        hsk_dns_rr_t *rr = hsk_dns_rr_create(HSK_DNS_A);
+        if (!rr)
+          return false;
+
+        hsk_dns_rr_set_name(rr, c->name);
+        rr->ttl = res->ttl;
+
+        hsk_dns_a_rd_t *rd = rr->rd;
+        memcpy(&rd->addr[0], &c->inet4[0], 4);
+
+        hsk_dns_rrs_push(an, rr);
+
+        break;
+      }
       case HSK_SYNTH4: {
         hsk_dns_rr_t *rr = hsk_dns_rr_create(HSK_DNS_A);
-
         if (!rr)
           return false;
 
@@ -661,7 +666,7 @@ hsk_resource_to_glue(
         // We are bypassing the checks in hsk_dns_rr_set_name()
         // which should be fine because the name is being derived, not received.
         char b32[29];
-        ip_to_b32(c->inet4, b32, 4);
+        hsk_base32_encode_hex(c->inet4, 4, b32, false);
         sprintf(rr->name, "_%s._synth.", b32);
 
         rr->ttl = res->ttl;
@@ -673,17 +678,31 @@ hsk_resource_to_glue(
 
         break;
       }
-      case HSK_GLUE6:
+      case HSK_GLUE6: {
         if (!hsk_dns_is_subdomain(tld, c->name))
-          continue;
+          break;
+
+        hsk_dns_rr_t *rr = hsk_dns_rr_create(HSK_DNS_AAAA);
+        if (!rr)
+          return false;
+
+        hsk_dns_rr_set_name(rr, c->name);
+        rr->ttl = res->ttl;
+
+        hsk_dns_aaaa_rd_t *rd = rr->rd;
+        memcpy(&rd->addr[0], &c->inet6[0], 16);
+
+        hsk_dns_rrs_push(an, rr);
+
+        break;
+      }
       case HSK_SYNTH6: {
         hsk_dns_rr_t *rr = hsk_dns_rr_create(HSK_DNS_AAAA);
-
         if (!rr)
           return false;
 
         char b32[29];
-        ip_to_b32(c->inet6, b32, 16);
+        hsk_base32_encode_hex(c->inet6, 16, b32, false);
         sprintf(rr->name, "_%s._synth.", b32);
 
         rr->ttl = res->ttl;
@@ -1134,144 +1153,6 @@ to_fqdn(char *name) {
   name[len + 1] = '\0';
 }
 
-static void
-ip_size(const uint8_t *ip, size_t *s, size_t *l) {
-  bool out = true;
-  int last = 0;
-  int i = 0;
-
-  int start = 0;
-  int len = 0;
-
-  for (; i < 16; i++) {
-    uint8_t ch = ip[i];
-    if (out == (ch == 0)) {
-      if (!out && i - last > len) {
-        start = last;
-        len = i - last;
-      }
-      out = !out;
-      last = i;
-    }
-  }
-
-  if (!out && i - last > len) {
-    start = last;
-    len = i - last;
-  }
-
-  // The worst case:
-  // We need at least 2 zeroes in a row to
-  // get any benefit from the compression.
-  if (len == 16) {
-    assert(start == 0);
-    len = 0;
-  }
-
-  assert(start < 16);
-  assert(len < 16);
-  assert(start + len <= 16);
-
-  *s = (size_t)start;
-  *l = (size_t)len;
-}
-
-static size_t
-ip_write(const uint8_t *ip, uint8_t *data) {
-  size_t start, len;
-  ip_size(ip, &start, &len);
-  uint8_t left = 16 - (start + len);
-  data[0] = (start << 4) | len;
-  // Ignore the missing section.
-  memcpy(&data[1], ip, start);
-  memcpy(&data[1 + start], &ip[start + len], left);
-  return 1 + start + left;
-}
-
-static bool
-ip_read(const uint8_t *data, uint8_t *ip) {
-  uint8_t field = data[0];
-
-  uint8_t start = field >> 4;
-  uint8_t len = field & 0x0f;
-
-  if (start + len > 16)
-    return false;
-
-  uint8_t left = 16 - (start + len);
-
-  // Front half.
-  if (ip)
-    memcpy(ip, &data[1], start);
-
-  // Fill in the missing section.
-  if (ip)
-    memset(&ip[start], 0x00, len);
-
-  // Back half.
-  if (ip)
-    memcpy(&ip[start + len], &data[1 + start], left);
-
-  return true;
-}
-
-void
-ip_to_b32(const uint8_t *ip, char *dst, uint8_t family) {
-  uint8_t mapped[16];
-
-  if (family == 4) {
-    // https://tools.ietf.org/html/rfc4291#section-2.5.5.2
-    memset(&mapped[0], 0x00, 10);
-    memset(&mapped[10], 0xff, 2);
-    memcpy(&mapped[12], ip, 4);
-  } else {
-    memcpy(&mapped[0], ip, 16);
-  }
-
-  uint8_t data[17];
-
-  size_t size = ip_write(mapped, data);
-  assert(size <= 17);
-
-  size_t b32_size = hsk_base32_encode_hex_size(data, size, false);
-  assert(b32_size <= 29);
-
-  hsk_base32_encode_hex(data, size, dst, false);
-}
-
-bool
-b32_to_ip(const char *str, uint8_t *ip, uint16_t *family) {
-  size_t size = hsk_base32_decode_hex_size(str);
-
-  if (size == 0 || size > 17)
-    return false;
-
-  uint8_t data[17];
-  assert(hsk_base32_decode_hex(str, data, false));
-
-  if (!ip_read(data, ip))
-    return false;
-
-  if (ip) {
-    static const uint8_t mapped[12] = {
-      0x00, 0x00, 0x00, 0x00,
-      0x00, 0x00, 0x00, 0x00,
-      0x00, 0x00, 0xff, 0xff
-    };
-
-    if (memcmp(ip, (void *)&mapped[0], 12) == 0) {
-      memcpy(&ip[0], &ip[12], 4);
-      if (family)
-        *family = HSK_DNS_A;
-    } else {
-      if (family)
-        *family = HSK_DNS_AAAA;
-    }
-  }
-
-  return true;
-}
-
 bool
 pointer_to_ip(const char *name, uint8_t *ip, uint16_t *family) {
   char label[HSK_DNS_MAX_LABEL + 1];
@@ -1280,7 +1161,20 @@ pointer_to_ip(const char *name, uint8_t *ip, uint16_t *family) {
   if (len < 2 || len > 29 || label[0] != '_')
     return false;
 
-  return b32_to_ip(&label[1], ip, family);
+  int j = hsk_base32_decode_hex(&label[1], ip, false);
+  assert(j);
+
+  if (j == 4) {
+    if (family)
+      *family = HSK_DNS_A;
+  } else if (j == 16) {
+    if (family)
+      *family = HSK_DNS_AAAA;
+  } else {
+    return false;
+  }
+
+  return true;
 }
 
 bool

--- a/src/resource.c
+++ b/src/resource.c
@@ -657,7 +657,13 @@ hsk_resource_to_glue(
         if (!rr)
           return false;
 
-        hsk_dns_rr_set_name(rr, c->name);
+        // Compute the base32 name from the SYNTH IP address.
+        // We are bypassing the checks in hsk_dns_rr_set_name()
+        // which should be fine because the name is being derived, not received.
+        char b32[29];
+        ip_to_b32(c->inet4, b32, 4);
+        sprintf(rr->name, "_%s._synth.", b32);
+
         rr->ttl = res->ttl;
 
         hsk_dns_a_rd_t *rd = rr->rd;
@@ -676,7 +682,10 @@ hsk_resource_to_glue(
         if (!rr)
           return false;
 
-        hsk_dns_rr_set_name(rr, c->name);
+        char b32[29];
+        ip_to_b32(c->inet6, b32, 16);
+        sprintf(rr->name, "_%s._synth.", b32);
+
         rr->ttl = res->ttl;
 
         hsk_dns_aaaa_rd_t *rd = rr->rd;

--- a/test/hnsd-test.c
+++ b/test/hnsd-test.c
@@ -1,0 +1,72 @@
+#include <assert.h>
+#include "base32.h"
+#include "resource.h"
+#include "resource.c"
+
+void
+print_array(uint8_t *arr, size_t size){
+  for (int i = 0; i < size; i++) {
+    printf("%x", arr[i]);
+  }
+  printf("\n");
+}
+
+void
+test_base32() {
+  const char *str = "5l6tm80";
+  const uint8_t expected[4] = {45, 77, 219, 32};
+
+  uint8_t ip[4];
+  hsk_base32_decode_hex(str, ip, false);
+  for (int i = 0; i < 4; i++) {
+    assert(ip[i] == expected[i]);
+  }
+
+  char encoded[8];
+  hsk_base32_encode_hex(ip, 4, encoded, false);
+  assert(strcmp(encoded, str) == 0);
+}
+
+void
+test_pointer_to_ip() {
+  const char *str4 = "_5l6tm80._synth";
+  const uint8_t expected4[4] = {45, 77, 219, 32};
+  uint8_t ip4[4];
+  uint16_t family4;
+
+  bool ret4 = pointer_to_ip(str4, ip4, &family4);
+  assert(ret4);
+  for (int i = 0; i < 4; i++) {
+    assert(ip4[i] == expected4[i]);
+  }
+  assert(family4 == HSK_DNS_A);
+
+  const char *str6 = "_400hjs000l2gol000fvvsc9cpg._synth";
+  const uint8_t expected6[16] = {
+    0x20, 0x01, 0x19, 0xf0,
+    0x00, 0x05, 0x45, 0x0c,
+    0x54, 0x00, 0x03, 0xff,
+    0xfe, 0x31, 0x2c, 0xcc
+  };
+
+  uint8_t ip6[16];
+  uint16_t family6;
+
+  bool ret6 = pointer_to_ip(str6, ip6, &family6);
+  assert(ret6);
+  for (int i = 0; i < 16; i++) {
+    assert(ip6[i] == expected6[i]);
+  }
+  assert(family6 == HSK_DNS_AAAA);
+}
+
+int
+main() {
+  printf("Testing hnsd...\n");
+  test_base32();
+  test_pointer_to_ip();
+
+  printf("ok\n");
+
+  return 0;
+}


### PR DESCRIPTION
Way back in https://github.com/handshake-org/hnsd/pull/32 I made a few mistakes that left SYNTH records broken in hnsd. While they could be _returned_ from a resource if the root ns was queried directly for an HNS name with a SYNTH record, a few things did not work:

 - root ns would decode and answer queries for synth records on the fly
 - when generating glue from a SYNTH record, the hostname was incorrect (left in initial state)

On mainnet HNS I have a name `omnitude` with both SYNTH4 and SYNTH6 records, and a nameserver and webserver in production at the corresponding IP. For review and testing, I ran hsd in regtest and just "won" that name again so I could insert the mainnet record set:

```
{
  "records": [
    {
      "type": "SYNTH4",
      "address": "45.77.219.32"
    },
    {
      "type": "DS",
      "keyTag": 26614,
      "algorithm": 8,
      "digestType": 2,
      "digest": "a20bc6f9ada0883326a05374d0d0c0e6290cef580d00b9b95770301441733b7f"
    },
    {
      "type": "SYNTH6",
      "address": "2001:19f0:5:450c:5400:3ff:fe31:2ccc"
    }
  ]
}
```

Then you can `./configure --with-network=regtest` and `make` hnsd with and without this PR to see the problem and its solution:

## Master 

glue records missing hostname from root ns:

```
--> dig @127.0.0.1 -p 25349 omnitude ns

...

;; AUTHORITY SECTION:
omnitude.               21600   IN      NS      _1bvvubadrcg0._synth.
omnitude.               21600   IN      NS      _84g026fg0l2gol000fvvsc9cpg._synth.

;; ADDITIONAL SECTION:
.                       21600   IN      A       45.77.219.32
.                       21600   IN      AAAA    2001:19f0:5:450c:5400:3ff:fe31:2ccc
```

root ns not decoding and answering synth records:

```
--> dig @127.0.0.1 -p 25349 _1bvvubadrcg0._synth.

;; ->>HEADER<<- opcode: QUERY, status: NXDOMAIN, id: 43875
;; flags: qr aa rd; QUERY: 1, ANSWER: 0, AUTHORITY: 1, ADDITIONAL: 1
;; WARNING: recursion requested but not available

...

;; AUTHORITY SECTION:
.                       86400   IN      SOA     . . 2021073116 1800 900 604800 86400
```

recursion failure on name with synth record:

```
--> dig @127.0.0.1 -p 25350 omnitude

; <<>> DiG 9.16.10 <<>> @127.0.0.1 -p 25350 omnitude
; (1 server found)
;; global options: +cmd
;; Got answer:
;; ->>HEADER<<- opcode: QUERY, status: SERVFAIL, id: 30711
;; flags: qr rd ra; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 1

;; OPT PSEUDOSECTION:
; EDNS: version: 0, flags:; udp: 4096
;; QUESTION SECTION:
;omnitude.                      IN      A
```

## With this patch in place

correct hostname in glue from root ns:

```
--> dig @127.0.0.1 -p 25349 omnitude ns

...

;; AUTHORITY SECTION:
omnitude.               21600   IN      NS      _1bvvubadrcg0._synth.
omnitude.               21600   IN      NS      _84g026fg0l2gol000fvvsc9cpg._synth.

;; ADDITIONAL SECTION:
_1bvvubadrcg0._synth.   21600   IN      A       45.77.219.32
_84g026fg0l2gol000fvvsc9cpg._synth. 21600 IN AAAA 2001:19f0:5:450c:5400:3ff:fe31:2ccc
```

direct decoding of synth names from root ns:

```
--> dig @127.0.0.1 -p 25349 _1bvvubadrcg0._synth.

...

;; ANSWER SECTION:
_1bvvubadrcg0._synth.   21600   IN      A       45.77.219.32
```

successful recursion including live nameserver:

```
--> dig @127.0.0.1 -p 25350 omnitude

...

;; ANSWER SECTION:
omnitude.               293     IN      A       45.77.219.32
```