### PR TITLE
Cache memleak

### DIFF
--- a/src/cache.c
+++ b/src/cache.c
@@ -81,8 +81,10 @@ hsk_cache_insert_data(
   hsk_cache_item_t *cache = hsk_map_get(&c->map, &ck);
 
   if (cache) {
-    if (hsk_now() < cache->time + 6 * 60 * 60)
+    if (hsk_now() < cache->time + 6 * 60 * 60) {
+      free(wire);
       return true;
+    }
 
     hsk_map_del(&c->map, &ck);
     hsk_cache_item_free(cache);
@@ -105,7 +107,8 @@ hsk_cache_insert_data(
   item->time = hsk_now();
 
   if (!hsk_map_set(&c->map, &item->key, item)) {
-    free(item->msg);
+    // hsk_cache_insert will free msg on false
+    item->msg = NULL;
     free(item);
     return false;
   }
@@ -129,6 +132,7 @@ hsk_cache_insert(
 
   if (!hsk_cache_insert_data(c, req->name, req->type, wire, wire_len)) {
     hsk_cache_log(c, "could not insert cache\n");
+    free(wire);
     return false;
   }
 


### PR DESCRIPTION
This is next memleak found with `make CFLAGS=-fsanitize=leak` and fixes another
leak logged in https://github.com/handshake-org/hnsd/issues/45 by @pinheadmz.

It's highly likely to be related to this:
```
==262390== 73,597 bytes in 294 blocks are definitely lost in loss record 18 of 21
==262390==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==262390==    by 0x12B315: hsk_dns_msg_encode (dns.c:178)
==262390==    by 0x120CC3: hsk_cache_insert (in /home/pinheadmz/Desktop/work/hnsd/hnsd)
==262390==    by 0x1222E8: after_resolve (in /home/pinheadmz/Desktop/work/hnsd/hnsd)
```

You can replicate it with sanitizer this way:
  - `make CFLAGS=-fsanitize=leak`
  - `./hnsd -r 127.0.0.1:1553`
  - wait for some time to sync (I just wait til 10k)
  - `dig @127.0.0.1 -p 1553 handshake.org`
  - wait for it to resolve (sometimes it may with different error in unbound,
    this PR is not about that)
   - C-c hnsd

You should see following message:
```
=================================================================
==663041==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 11595 byte(s) in 8 object(s) allocated from:
    #0 0x7f987da5abc2 in __interceptor_malloc /build/gcc/src/gcc/libsanitizer/lsan/lsan_interceptors.cpp:56
    #1 0x55d3f0524371 in hsk_dns_msg_encode src/dns.c:178

SUMMARY: LeakSanitizer: 11595 byte(s) leaked in 8 allocation(s).
```

This PR is an attempt to fix that leak.

Story of the `hsk_dns_msg_encode`:
  `hsk_dns_msg_encode` is responsible to create `wire` representation of the
`hsk_dns_msg_t` struct. It is *allocates* buffer for the wire representation
and leaves responsibility of freeing that data to the caller.

  Major callers for this method are: `rs.c`, `ns.c` via `hsk_dns_msg_finalize`
method(defined in `req.c`) and `cache.c` when inserting into cache in
`hsk_cache_insert`. `rs.c` and `ns.c` are similar in the structure and both
use `wire` with `hsk_rs_send` and `hsk_ns_send` which both free this data
after using (as far as I have seen) - you can see `should_free` variable and
`after_send` callbacks in work.

  `hsk_cache_insert` on the other hand does not free this buffer in all cases.
After this fix new behaviour of `hsk_cache_insert_data` will be: if it is
successful it will free the data (only when cache is still valid) and if it
returns false it will become `hsk_cache_insert` methods responsibility to free
that data.

This could be avoided if we had more strict rules about the allocation/free
responsibilities and could be different (and better) solution to this:

  Move allocation of the wire buffer outside of the `hsk_dns_msg_encode`, we
would call `hsk_dns_msg_size` from the outside everywhere we need `wire`
serialization to allocate.
It would require slightly more refactor and decided to keep it minimal with
this PR.
