### PR TITLE
Fix hsk_dns_txt leaks

### DIFF
--- a/src/dns.c
+++ b/src/dns.c
@@ -1666,11 +1666,15 @@ hsk_dns_rd_read(
         if (!txt)
           goto fail_txt;
 
-        if (!read_u8(data, data_len, &txt->data_len))
+        if (!read_u8(data, data_len, &txt->data_len)) {
+          hsk_dns_txt_free(txt);
           goto fail_txt;
+        }
 
-        if (!read_bytes(data, data_len, txt->data, txt->data_len))
+        if (!read_bytes(data, data_len, txt->data, txt->data_len)) {
+          hsk_dns_txt_free(txt);
           goto fail_txt;
+        }
 
         hsk_dns_txts_push(&r->txts, txt);
       }

--- a/src/resource.c
+++ b/src/resource.c
@@ -293,6 +293,10 @@ hsk_record_free(hsk_record_t *r) {
     }
     case HSK_TEXT: {
       hsk_txt_record_t *rec = (hsk_txt_record_t *)r;
+
+      int i;
+      for (i = 0; i < rec->txts.size; i++)
+        hsk_dns_txt_free(rec->txts.items[i]);
       free(rec);
       break;
     }


### PR DESCRIPTION
This is also logged in #45 by @pinheadmz and happens in `ns.c - after_resolve` as mentioned in the logs:

```

==262390== 2,628,352 bytes in 10,267 blocks are definitely lost in loss record 21 of 21
==262390==    at 0x483B7F3: malloc (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==262390==    by 0x12876F: hsk_dns_txt_alloc (dns.c:2075)
==262390==    by 0x137B73: hsk_txt_record_read (resource.c:144)
==262390==    by 0x137F27: hsk_record_read (resource.c:376)
==262390==    by 0x1380BB: hsk_resource_decode (resource.c:436)
==262390==    by 0x1221C0: after_resolve (in /home/pinheadmz/Desktop/work/hnsd/hnsd)
==262390==    by 0x133FEB: hsk_peer_handle_proof (pool.c:1525)
==262390==    by 0x133FEB: hsk_peer_handle_msg (pool.c:1584)
==262390==    by 0x133FEB: hsk_peer_parse (pool.c:1696)
==262390==    by 0x133FEB: hsk_peer_on_read.part.0 (pool.c:1606)
==262390==    by 0x1534AC: hsk_brontide_parse (brontide.c:776)
==262390==    by 0x153709: hsk_brontide_on_read (brontide.c:629)
==262390==    by 0x13453B: after_read (pool.c:1807)
==262390==    by 0x161B80: uv__read (stream.c:1249)
==262390==    by 0x162527: uv__stream_io (stream.c:1316)
```

Even though the struct is called `hsk_dns_txt_t` it is reused in `hsk_txt_record_t.hsk_dns_txts_t`.
`hsk_dns_txt_t` is part of the struct but `hsk_dns_txts_t` itself contains pointers to malloced `hsk_dns_txt_t`, which were not being freed by `hsk_record_free`.

Reproduce with leak santiizer:
  - `make CFLAGS="-fsanitize=leak"`
  - `./hnsd -p 4 -r 127.0.0.1:1553`
  - `dig @127.0.0.1 -p 1553 proofofconcept`
You should only see leaks that are fixed in #73 


Fix in dns.c:
 while looking into this also found another leak in case of `read_u8` and `read_bytes` failure in `hsk_dns_rd_read`. Because these two failures cause goto to fail_txt where r->txts are cleaned up and this `txt` record have not been pushed to the txts list yet, so it will leak. This have not been caught by the leak detector and was not able to reproduce, but still decided to fix it.