### PR TITLE
daemon/pool: allow user to set supplemental user agent string

### DIFF
--- a/src/pool.h
+++ b/src/pool.h
@@ -104,6 +104,7 @@ typedef struct hsk_pool_s {
   int pending_count;
   int64_t block_time;
   int64_t getheaders_time;
+  char *user_agent;
 } hsk_pool_t;
 
 /*
@@ -124,6 +125,9 @@ hsk_pool_set_size(hsk_pool_t *pool, int max_size);
 
 bool
 hsk_pool_set_seeds(hsk_pool_t *pool, const char *seeds);
+
+bool
+hsk_pool_set_agent(hsk_pool_t *pool, const char *user_agent);
 
 hsk_pool_t *
 hsk_pool_alloc(const uv_loop_t *loop);


### PR DESCRIPTION
Usage:

```
./hnsd -a bacon

# or

./hnsd --user-agent bacon
```

Result (from hsd):

```
--> hsd-rpc getpeerinfo
[
  {
    "id": 13,
    "addr": "127.0.0.1:64061",
    "addrlocal": "127.0.0.1:10000",
    "services": "00000000",
    "servicenames": [],
    "relaytxes": false,
    "lastsend": 1639587864,
    "lastrecv": 1639587864,
    "bytessent": 35343,
    "bytesrecv": 249,
    "conntime": 1,
    "timeoffset": 0,
    "pingtime": -1,
    "minping": -1,
    "version": 1,
    "subver": "/hnsd:1.0.0/bacon",
    "inbound": true,
    "startingheight": 0,
    "besthash": "0000000000000000000000000000000000000000000000000000000000000000",
    "bestheight": -1,
    "banscore": 0,
    "inflight": [],
    "whitelisted": false
  }
]
```