### PR TITLE
Daemon separate close and free

### DIFF
--- a/src/pool.c
+++ b/src/pool.c
@@ -173,7 +173,7 @@ hsk_pool_init(hsk_pool_t *pool, const uv_loop_t *loop) {
   pool->pending_count = 0;
   pool->block_time = 0;
   pool->getheaders_time = 0;
-  pool->user_agent = (char *)malloc(255);
+  pool->user_agent = (char *)malloc(256);
   strcpy(pool->user_agent, HSK_USER_AGENT);
 
   return HSK_SUCCESS;
@@ -302,7 +302,7 @@ hsk_pool_set_agent(hsk_pool_t *pool, const char *user_agent) {
   if (!user_agent)
     return true;
 
-  size_t len = strlen(pool->user_agent);  
+  size_t len = strlen(pool->user_agent);
   len += strlen(user_agent);
 
   // Agent size in p2p version message is 1 byte


### PR DESCRIPTION
### Fix malloc for user agent.
  https://github.com/handshake-org/hnsd/blob/d2bb5f4c77c2cb2aba18be7c57ce6ffe9abca821/src/pool.c#L309-L312
  strcat will put `\0` byte outside allocated memory when passed string with length `255-12`
  (12 -/hnsd:1.0.0/ length).

It did not crash, but still.
This will be command if you want to replicate issue:

```sh
./hnsd -a `node -e 'console.log("a".repeat(255 - 12))'` # Just run with aaaa...
gdb --args ./hnsd -a `node -e 'console.log("a".repeat(255 -12))'` # Gdb to check memory
```

### Separate close and free in the daemon

I noticed that daemon would segfault if the user agent check failed (`hsk_pool_set_agent`).
Reproduce with:
```sh
./hnsd -a `node -e 'console.log("a".repeat(255))'` 
```

The reason it fails is the fail label in the `hsk_daemon_init` that calls `hsk_daemon_after_close`.
`hsk_daemon_after_close`(this is basically close method for the main thread) does not differentiate between
stages of allocation and open and tries to close them anyway.

This PR introduces `hsk_daemon_uninit`, which only calls free for the daemon props. It is still called
by `hsk_daemon_after_close`, but the `hsk_daemon_init` will only call `uninit` function.
