### PR TITLE
ci: integration test with hsd (big fix 4/4)

### DIFF
--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -26,9 +26,16 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build
-        run: ./autogen.sh && ./configure && make
+        run: ./autogen.sh && ./configure --with-network=regtest && make
 
       - name: Unit Tests
         run: ./test_hnsd
 
-    # TODO: Install nodejs, intall hsd and test end-to-end integration.
+      - name: Setup Integration
+        uses: actions/setup-node@v1
+
+      - name: Integration Tests
+        working-directory: ./test/integration
+        run:  |
+              npm install
+              ./node_modules/bmocha/bin/bmocha --reporter spec hnsd-integration-test.js

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,16 @@ jobs:
         run: sudo apt-get install -y libunbound-dev
 
       - name: Build
-        run: ./autogen.sh && ./configure && make
+        run: ./autogen.sh && ./configure --with-network=regtest && make
 
       - name: Unit Tests
         run: ./test_hnsd
 
-      # TODO: Install nodejs, intall hsd and test end-to-end integration.
+      - name: Setup Integration
+        uses: actions/setup-node@v1
+
+      - name: Integration Tests
+        working-directory: ./test/integration
+        run:  |
+              npm install
+              ./node_modules/bmocha/bin/bmocha --reporter spec hnsd-integration-test.js

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ m4/ltversion.m4
 m4/lt~obsolete.m4
 src/stamp-h1
 test_hnsd
+test/integration/node_modules/

--- a/test/integration/hnsd-integration-test.js
+++ b/test/integration/hnsd-integration-test.js
@@ -1,0 +1,278 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+/* eslint max-len: "off" */
+/* eslint no-return-assign: "off" */
+'use strict';
+
+const {spawn} = require('child_process');
+const path = require('path');
+const assert = require('bsert');
+const {FullNode} = require('hsd');
+const dns = require('bns/lib/dns');
+const wire = require('bns/lib/wire');
+
+describe('hnsd Integration Test', function() {
+  const node = new FullNode({
+    memory: true,
+    network: 'regtest',
+    listen: true,
+    port: 10000,
+    noDns: true,
+    plugins: [require('hsd/lib/wallet/plugin')]
+  });
+
+  const resolver = new dns.Resolver({
+    host: '127.0.0.1',
+    port: 25349,
+    dnssec: true
+  });
+  resolver.setServers(['127.0.0.1:25349']);
+
+  const hnsdPath = path.join(__dirname, '..', '..', 'hnsd');
+  let hnsd;
+
+  function find(rrs, type) {
+    for (const rr of rrs) {
+      // return first found
+      if (rr.type === wire.types[type])
+        return rr;
+    }
+    return null;
+  }
+
+  before(async () => {
+    await node.open();
+    await node.connect();
+
+    hnsd = spawn(
+      hnsdPath,
+      ['-s', '127.0.0.1:10000'],
+      {shell: false}
+    );
+  });
+
+  after(async () => {
+    hnsd.kill('SIGKILL');
+    await node.close();
+  });
+
+  it('should register names', async() => {
+    const addr = await node.plugins.walletdb.rpc.getNewAddress(['default']);
+    await node.rpc.generateToAddress([100, addr]);
+    await node.plugins.walletdb.rpc.sendOpen(['test-ds']);
+    await node.plugins.walletdb.rpc.sendOpen(['test-ns']);
+    await node.plugins.walletdb.rpc.sendOpen(['test-txt']);
+    await node.plugins.walletdb.rpc.sendOpen(['test-glue4-glue']);
+    await node.rpc.generateToAddress([6, addr]);
+    await node.plugins.walletdb.rpc.sendBid(['test-ds', 1, 1]);
+    await node.plugins.walletdb.rpc.sendBid(['test-ns', 1, 1]);
+    await node.plugins.walletdb.rpc.sendBid(['test-txt', 1, 1]);
+    await node.plugins.walletdb.rpc.sendBid(['test-glue4-glue', 1, 1]);
+    await node.rpc.generateToAddress([6, addr]);
+    await node.plugins.walletdb.rpc.sendReveal([]);
+    await node.rpc.generateToAddress([10, addr]);
+    await node.plugins.walletdb.rpc.sendUpdate([
+      'test-ds',
+      {
+        'records':
+        [
+          {
+            'type': 'DS',
+            'keyTag': 57355,
+            'algorithm': 8,
+            'digestType': 2,
+            'digest': '95a57c3bab7849dbcddf7c72ada71a88146b141110318ca5be672057e865c3e2'
+          }
+        ]
+      }
+    ]);
+    await node.plugins.walletdb.rpc.sendUpdate([
+      'test-ns',
+      {
+        'records':
+        [
+          {
+            'type': 'NS',
+            'ns': 'ns1.hns.'
+          }
+        ]
+      }
+    ]);
+    await node.plugins.walletdb.rpc.sendUpdate([
+      'test-txt',
+      {
+        'records':
+        [
+          {
+            'type': 'TXT',
+            'txt': ['hello world']
+          }
+        ]
+      }
+    ]);
+    await node.plugins.walletdb.rpc.sendUpdate([
+      'test-glue4-glue',
+      {
+        'records':
+        [
+          {
+            'type': 'GLUE4',
+            'ns': 'ns1.test-glue4-glue.',
+            'address': '10.20.30.40'
+          }
+        ]
+      }
+    ]);
+    await node.rpc.generateToAddress([10, addr]);
+  });
+
+  it('doesnotexist / A', async() => {
+    const result = await resolver.resolveRaw('doesnotexist.', 'A');
+    const nsec = find(result.authority, 'NSEC');
+    assert(nsec);
+    assert.strictEqual(nsec.name, 'doesnotexiss\\255.');
+    assert.strictEqual(nsec.data.nextDomain, 'doesnotexist\\000.');
+    assert(nsec.data.toJSON().typeBitmap.includes(wire.types.NSEC));
+    assert(nsec.data.toJSON().typeBitmap.includes(wire.types.RRSIG));
+    assert(!nsec.data.toJSON().typeBitmap.includes(wire.types.A));
+    assert(!nsec.data.toJSON().typeBitmap.includes(wire.types.AAAA));
+  });
+
+  it('_synth / A', async() => {
+    const result = await resolver.resolveRaw('_synth.', 'A');
+    const nsec = find(result.authority, 'NSEC');
+    assert(nsec);
+    assert.strictEqual(nsec.name, '_synth.');
+    assert.strictEqual(nsec.data.nextDomain, '\\000._synth.');
+    assert(nsec.data.toJSON().typeBitmap.includes(wire.types.NSEC));
+    assert(nsec.data.toJSON().typeBitmap.includes(wire.types.RRSIG));
+    assert(!nsec.data.toJSON().typeBitmap.includes(wire.types.A));
+    assert(!nsec.data.toJSON().typeBitmap.includes(wire.types.AAAA));
+  });
+
+  it('_fs00008._synth. / A', async() => {
+    const result = await resolver.resolveRaw('_fs00008._synth.', 'A');
+    const a = find(result.answer, 'A');
+    assert(a);
+    assert.strictEqual(a.data.address, '127.0.0.1');
+  });
+
+  it('_fs00008._synth. / AAAA', async() => {
+    const result = await resolver.resolveRaw('_fs00008._synth.', 'AAAA');
+    const nsec = find(result.authority, 'NSEC');
+    assert(nsec);
+    assert.strictEqual(nsec.name, '_fs00008._synth.');
+    assert.strictEqual(nsec.data.nextDomain, '\\000._fs00008._synth.');
+    assert(nsec.data.toJSON().typeBitmap.includes(wire.types.A));
+    assert(nsec.data.toJSON().typeBitmap.includes(wire.types.NSEC));
+    assert(nsec.data.toJSON().typeBitmap.includes(wire.types.RRSIG));
+    assert(!nsec.data.toJSON().typeBitmap.includes(wire.types.AAAA));
+  });
+
+  it('badsynth._synth. / A', async() => {
+    const result = await resolver.resolveRaw('badsynth._synth.', 'A');
+    assert.strictEqual(result.question[0].name, 'badsynth._synth.');
+    assert.strictEqual(result.code, wire.codes.REFUSED);
+  });
+
+  it('test-ds / DS', async() => {
+    const result = await resolver.resolveRaw('test-ds.', 'DS');
+    assert(result.authority.length === 0);
+    const ds = find(result.answer, 'DS');
+    assert(ds);
+    assert.bufferEqual(
+      ds.data.digest,
+      Buffer.from('95a57c3bab7849dbcddf7c72ada71a88146b141110318ca5be672057e865c3e2', 'hex')
+    );
+  });
+
+  it('test-ds / NS', async() => {
+    const result = await resolver.resolveRaw('test-ds.', 'NS');
+    const nsec = find(result.authority, 'NSEC');
+    assert(nsec);
+    assert.strictEqual(nsec.name, 'test-ds.');
+    assert.strictEqual(nsec.data.nextDomain, 'test-ds\\000.');
+    assert(nsec.data.toJSON().typeBitmap.includes(wire.types.NSEC));
+    assert(nsec.data.toJSON().typeBitmap.includes(wire.types.RRSIG));
+    assert(!nsec.data.toJSON().typeBitmap.includes(wire.types.DS));
+    assert(!nsec.data.toJSON().typeBitmap.includes(wire.types.NS));
+  });
+
+  it('test-ns / NS', async() => {
+    const result = await resolver.resolveRaw('test-ns.', 'NS');
+    const ns = find(result.authority, 'NS');
+    assert(ns);
+    assert.strictEqual(ns.data.ns, 'ns1.hns.');
+
+    const nsec = find(result.authority, 'NSEC');
+    assert(nsec);
+    assert.strictEqual(nsec.name, 'test-ns.');
+    assert.strictEqual(nsec.data.nextDomain, 'test-ns\\000.');
+    assert(nsec.data.toJSON().typeBitmap.includes(wire.types.NSEC));
+    assert(nsec.data.toJSON().typeBitmap.includes(wire.types.RRSIG));
+    assert(nsec.data.toJSON().typeBitmap.includes(wire.types.NS));
+    assert(!nsec.data.toJSON().typeBitmap.includes(wire.types.DS));
+  });
+
+  it('test-txt / TXT', async() => {
+    const result = await resolver.resolveRaw('test-txt.', 'TXT');
+    const txt = find(result.answer, 'TXT');
+    assert(txt);
+    assert.strictEqual(txt.data.txt[0], 'hello world');
+  });
+
+  it('test-txt / NS', async() => {
+    const result = await resolver.resolveRaw('test-txt.', 'NS');
+    const nsec = find(result.authority, 'NSEC');
+    assert(nsec);
+    assert.strictEqual(nsec.name, 'test-txt.');
+    assert.strictEqual(nsec.data.nextDomain, 'test-txt\\000.');
+    assert(nsec.data.toJSON().typeBitmap.includes(wire.types.NSEC));
+    assert(nsec.data.toJSON().typeBitmap.includes(wire.types.RRSIG));
+    assert(nsec.data.toJSON().typeBitmap.includes(wire.types.TXT));
+    assert(!nsec.data.toJSON().typeBitmap.includes(wire.types.DS));
+    assert(!nsec.data.toJSON().typeBitmap.includes(wire.types.NS));
+  });
+
+  it('test-glue4-glue / NS', async() => {
+    const result = await resolver.resolveRaw('test-glue4-glue.', 'NS');
+    const ns = find(result.authority, 'NS');
+    assert(ns);
+    assert.strictEqual(ns.data.ns, 'ns1.test-glue4-glue.');
+
+    const a = find(result.additional, 'A');
+    assert(a);
+    assert.strictEqual(a.data.address, '10.20.30.40');
+
+    const nsec = find(result.authority, 'NSEC');
+    assert(nsec);
+    assert.strictEqual(nsec.name, 'test-glue4-glue.');
+    assert.strictEqual(nsec.data.nextDomain, 'test-glue4-glue\\000.');
+    assert(nsec.data.toJSON().typeBitmap.includes(wire.types.NSEC));
+    assert(nsec.data.toJSON().typeBitmap.includes(wire.types.RRSIG));
+    assert(nsec.data.toJSON().typeBitmap.includes(wire.types.NS));
+    assert(!nsec.data.toJSON().typeBitmap.includes(wire.types.TXT));
+    assert(!nsec.data.toJSON().typeBitmap.includes(wire.types.DS));
+  });
+
+  it('foo\\200 / A', async() => {
+    const result = await resolver.resolveRaw('foo\\200.', 'A');
+    assert.strictEqual(result.question[0].name, 'foo\\200.');
+    assert.strictEqual(result.code, wire.codes.REFUSED);
+  });
+
+  it('\\\\ducks.doesnotexist2. / A', async() => {
+    const result = await resolver.resolveRaw('\\\\ducks.doesnotexist2.', 'A');
+    assert.strictEqual(result.question[0].name, '\\\\ducks.doesnotexist2.');
+
+    const nsec = find(result.authority, 'NSEC');
+    assert(nsec);
+    assert.strictEqual(nsec.name, 'doesnotexist1\\255.');
+    assert.strictEqual(nsec.data.nextDomain, 'doesnotexist2\\000.');
+    assert(nsec.data.toJSON().typeBitmap.includes(wire.types.NSEC));
+    assert(nsec.data.toJSON().typeBitmap.includes(wire.types.RRSIG));
+    assert(!nsec.data.toJSON().typeBitmap.includes(wire.types.NS));
+    assert(!nsec.data.toJSON().typeBitmap.includes(wire.types.TXT));
+    assert(!nsec.data.toJSON().typeBitmap.includes(wire.types.DS));
+  });
+});

--- a/test/integration/package-lock.json
+++ b/test/integration/package-lock.json
@@ -1,0 +1,325 @@
+{
+  "name": "hnsd_integration_test",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "bcfg": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/bcfg/-/bcfg-0.1.7.tgz",
+      "integrity": "sha512-+4beq5bXwfmxdcEoHYQsaXawh1qFzjLcRvPe5k5ww/NEWzZTm56Jk8LuPmfeGB7X584jZ8xGq6UgMaZnNDa5Ww==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bcrypto": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-5.4.0.tgz",
+      "integrity": "sha512-KDX2CR29o6ZoqpQndcCxFZAtYA1jDMnXU3jmCfzP44g++Cu7AHHtZN/JbrN/MXAg9SLvtQ8XISG+eVD9zH1+Jg==",
+      "requires": {
+        "bufio": "~1.0.7",
+        "loady": "~0.0.5"
+      }
+    },
+    "bcurl": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/bcurl/-/bcurl-0.1.10.tgz",
+      "integrity": "sha512-NPxrIkc61tI2FvuibKW8IHaWs7YpgGvOWTgYEJYoE0vOiCvjuL6PXeKYq6bZqadeZfQ6v+R74qvj3Siiv+/Pvg==",
+      "requires": {
+        "brq": "~0.1.8",
+        "bsert": "~0.0.10",
+        "bsock": "~0.1.9"
+      }
+    },
+    "bdb": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bdb/-/bdb-1.3.0.tgz",
+      "integrity": "sha512-oJnWnHOTcnJhazwpEzQvPFtSR1IdHtS3PczuLY3klgZTTtRUbARX7tdphQS8iNUUwEVMfuO93eHDWwTICoeJlg==",
+      "requires": {
+        "bsert": "~0.0.10",
+        "loady": "~0.0.5"
+      }
+    },
+    "bdns": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/bdns/-/bdns-0.1.5.tgz",
+      "integrity": "sha512-LNVkfM7ynlAD0CvPvO9cKxW8YXt1KOCRQZlRsGZWeMyymUWVdHQpZudAzH9chaFAz6HiwAnQxwDemCKDPy6Mag==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bevent": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/bevent/-/bevent-0.1.5.tgz",
+      "integrity": "sha512-hs6T3BjndibrAmPSoKTHmKa3tz/c6Qgjv9iZw+tAoxuP6izfTCkzfltBQrW7SuK5xnY22gv9jCEf51+mRH+Qvg==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bfile": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/bfile/-/bfile-0.2.2.tgz",
+      "integrity": "sha512-X205SsJ7zFAnjeJ/pBLqDqF10x/4Su3pBy8UdVKw4hdGJk7t5pLoRi+uG4rPaDAClGbrEfT/06PGUbYiMYKzTg=="
+    },
+    "bfilter": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/bfilter/-/bfilter-1.0.5.tgz",
+      "integrity": "sha512-GupIidtCvLbKhXnA1sxvrwa+gh95qbjafy7P1U1x/2DHxNabXq4nGW0x3rmgzlJMYlVl+c8fMxoMRIwpKYlgcQ==",
+      "requires": {
+        "bsert": "~0.0.10",
+        "bufio": "~1.0.6",
+        "mrmr": "~0.1.6"
+      }
+    },
+    "bheep": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/bheep/-/bheep-0.1.5.tgz",
+      "integrity": "sha512-0KR5Zi8hgJBKL35+aYzndCTtgSGakOMxrYw2uszd5UmXTIfx3+drPGoETlVbQ6arTdAzSoQYA1j35vbaWpQXBg==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "binet": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/binet/-/binet-0.3.6.tgz",
+      "integrity": "sha512-6pm+Gc3uNiiJZEv0k8JDWqQlo9ki/o9UNAkLmr0EGm7hI5MboOJVIOlO1nw3YuDkLHWN78OPsaC4JhRkn2jMLw==",
+      "requires": {
+        "bs32": "~0.1.5",
+        "bsert": "~0.0.10"
+      }
+    },
+    "blgr": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/blgr/-/blgr-0.2.0.tgz",
+      "integrity": "sha512-2jZdqajYCGD5rwGdOooQpxgjKsiAAV2g8LapwSnbTjAYTZAqmqBAS+GsVGFi+/y7t1Pspidv/5HsWBbJrsEuFw==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "blru": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/blru/-/blru-0.1.6.tgz",
+      "integrity": "sha512-34+xZ2u4ys/aUzWCU9m6Eee4nVuN1ywdxbi8b3Z2WULU6qvnfeHvCWEdGzlVfRbbhimG2xxJX6R77GD2cuVO6w==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "blst": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/blst/-/blst-0.1.5.tgz",
+      "integrity": "sha512-TPl04Cx3CHdPFAJ2x9Xx1Z1FOfpAzmNPfHkfo+pGAaNH4uLhS58ExvamVkZh3jadF+B7V5sMtqvrqdf9mHINYA==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bmocha": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/bmocha/-/bmocha-2.1.5.tgz",
+      "integrity": "sha512-hEO+jQC+6CMxdxSqKPjqAdIDvRWHfdGgsMh4fUmatkMewbYr2O6qMIbW7Lhcmkcnz8bwRHZuEdDaBt/16NofoA=="
+    },
+    "bmutex": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bmutex/-/bmutex-0.1.6.tgz",
+      "integrity": "sha512-nXWOXtQHbfPaMl6jyEF/rmRMrcemj2qn+OCAI/uZYurjfx7Dg3baoXdPzHOL0U8Cfvn8CWxKcnM/rgxL7DR4zw==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bns": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/bns/-/bns-0.15.0.tgz",
+      "integrity": "sha512-iJWQVE399vQzPfhalFMJGEQ7k5Ot2D6Mz8dkoPeLO8huWAMOiJNJ1tHzOu5j+ZyNNew6ITgG/LsSyaRPxvkXuw==",
+      "requires": {
+        "bcrypto": "~5.4.0",
+        "bfile": "~0.2.2",
+        "bheep": "~0.1.5",
+        "binet": "~0.3.6",
+        "bs32": "~0.1.6",
+        "bsert": "~0.0.10",
+        "btcp": "~0.1.5",
+        "budp": "~0.1.6",
+        "bufio": "~1.0.7",
+        "unbound": "~0.4.3"
+      }
+    },
+    "brq": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/brq/-/brq-0.1.8.tgz",
+      "integrity": "sha512-6SDY1lJMKXgt5TZ6voJQMH2zV1XPWWtm203PSkx3DSg9AYNYuRfOPFSBDkNemabzgpzFW9/neR4YhTvyJml8rQ==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bs32": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bs32/-/bs32-0.1.6.tgz",
+      "integrity": "sha512-usjDesQqZ8ihHXOnOEQuAdymBHnJEfSd+aELFSg1jN/V3iAf12HrylHlRJwIt6DTMmXpBDQ+YBg3Q3DIYdhRgQ==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bsert": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.10.tgz",
+      "integrity": "sha512-NHNwlac+WPy4t2LoNh8pXk8uaIGH3NSaIUbTTRXGpE2WEbq0te/tDykYHkFK57YKLPjv/aGHmbqvnGeVWDz57Q=="
+    },
+    "bsock": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/bsock/-/bsock-0.1.9.tgz",
+      "integrity": "sha512-/l9Kg/c5o+n/0AqreMxh2jpzDMl1ikl4gUxT7RFNe3A3YRIyZkiREhwcjmqxiymJSRI/Qhew357xGn1SLw/xEw==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bsocks": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bsocks/-/bsocks-0.2.6.tgz",
+      "integrity": "sha512-66UkjoB9f7lhT+WKgYq8MQa6nkr96mlX64JYMlIsXe/X4VeqNwvsx7UOE3ZqD6lkwg8GvBhapRTWj0qWO3Pw8w==",
+      "requires": {
+        "binet": "~0.3.5",
+        "bsert": "~0.0.10"
+      }
+    },
+    "btcp": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/btcp/-/btcp-0.1.5.tgz",
+      "integrity": "sha512-tkrtMDxeJorn5p0KxaLXELneT8AbfZMpOFeoKYZ5qCCMMSluNuwut7pGccLC5YOJqmuk0DR774vNVQLC9sNq/A=="
+    },
+    "budp": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/budp/-/budp-0.1.6.tgz",
+      "integrity": "sha512-o+a8NPq3DhV91j4nInjht2md6mbU1XL+7ciPltP66rw5uD3KP1m5r8lA94LZVaPKcFdJ0l2HVVzRNxnY26Pefg=="
+    },
+    "buffer-map": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buffer-map/-/buffer-map-0.0.7.tgz",
+      "integrity": "sha512-95try3p/vMRkIAAnJDaGkFhGpT/65NoeW6XelEPjAomWYR58RQtW4khn0SwKj34kZoE7uxL7w2koZSwbnszvQQ=="
+    },
+    "bufio": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.7.tgz",
+      "integrity": "sha512-bd1dDQhiC+bEbEfg56IdBv7faWa6OipMs/AFFFvtFnB3wAYjlwQpQRZ0pm6ZkgtfL0pILRXhKxOiQj6UzoMR7A=="
+    },
+    "bupnp": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bupnp/-/bupnp-0.2.6.tgz",
+      "integrity": "sha512-J6ykzJhZMxXKN78K+1NzFi3v/51X2Mvzp2hW42BWwmxIVfau6PaN99gyABZ8x05e8MObWbsAis23gShhj9qpbw==",
+      "requires": {
+        "binet": "~0.3.5",
+        "brq": "~0.1.7",
+        "bsert": "~0.0.10"
+      }
+    },
+    "bval": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bval/-/bval-0.1.6.tgz",
+      "integrity": "sha512-jxNH9gSx7g749hQtS+nTxXYz/bLxwr4We1RHFkCYalNYcj12RfbW6qYWsKu0RYiKAdFcbNoZRHmWrIuXIyhiQQ==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bweb": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/bweb/-/bweb-0.1.10.tgz",
+      "integrity": "sha512-3Kkz/rfsyAWUS+8DV5XYhwcgVN4DfDewrP+iFTcpQfdZzcF6+OypAq7dHOtXV0sW7U/3msA/sEEqz0MHZ9ERWg==",
+      "requires": {
+        "bsert": "~0.0.10",
+        "bsock": "~0.1.8"
+      }
+    },
+    "goosig": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/goosig/-/goosig-0.10.0.tgz",
+      "integrity": "sha512-+BVVLfxmawAmGVjjJpXzu5LNcFIOfgXgP7kWEyc3qu/xn9RMqbPbNfYDdHBZKfZkDMIO7Q4vD790iNYQAXhoFA==",
+      "requires": {
+        "bcrypto": "~5.4.0",
+        "bsert": "~0.0.10",
+        "loady": "~0.0.5"
+      }
+    },
+    "hsd": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hsd/-/hsd-3.0.1.tgz",
+      "integrity": "sha512-AI7ruyDhxyzKQzaDdEj0N2zjjYXjEPwQGlWQTootg85ByNKWQsAfZChvWqi2ek0FLPuNlM1toaDT+jcYi+UmqA==",
+      "requires": {
+        "bcfg": "~0.1.7",
+        "bcrypto": "~5.4.0",
+        "bdb": "~1.3.0",
+        "bdns": "~0.1.5",
+        "bevent": "~0.1.5",
+        "bfile": "~0.2.2",
+        "bfilter": "~1.0.5",
+        "bheep": "~0.1.5",
+        "binet": "~0.3.6",
+        "blgr": "~0.2.0",
+        "blru": "~0.1.6",
+        "blst": "~0.1.5",
+        "bmutex": "~0.1.6",
+        "bns": "~0.15.0",
+        "bsert": "~0.0.10",
+        "bsock": "~0.1.9",
+        "bsocks": "~0.2.6",
+        "btcp": "~0.1.5",
+        "buffer-map": "~0.0.7",
+        "bufio": "~1.0.7",
+        "bupnp": "~0.2.6",
+        "bval": "~0.1.6",
+        "bweb": "~0.1.10",
+        "goosig": "~0.10.0",
+        "hs-client": "~0.0.10",
+        "n64": "~0.2.10",
+        "urkel": "~0.7.0"
+      },
+      "dependencies": {
+        "hs-client": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/hs-client/-/hs-client-0.0.10.tgz",
+          "integrity": "sha512-15tfeQEMRS1FZA0q9gFbQ1jYs8v4z9oKw9xFwVEyRuckn72hoVAglN4IrFxkOCDMYV7TWCY/nO/yNZp5njYFBw==",
+          "requires": {
+            "bcfg": "~0.1.7",
+            "bcurl": "~0.1.9",
+            "bsert": "~0.0.10"
+          }
+        }
+      }
+    },
+    "loady": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/loady/-/loady-0.0.5.tgz",
+      "integrity": "sha512-uxKD2HIj042/HBx77NBcmEPsD+hxCgAtjEWlYNScuUjIsh/62Uyu39GOR68TBR68v+jqDL9zfftCWoUo4y03sQ=="
+    },
+    "mrmr": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/mrmr/-/mrmr-0.1.10.tgz",
+      "integrity": "sha512-NJRJs+yJyRWwcTqLRf7O32n56UP1+UQoTrGVEoB3LMj0h2jlon790drDbxKvi5mK5k4HfC0cpNkxqHcrJK/evg==",
+      "requires": {
+        "bsert": "~0.0.10",
+        "loady": "~0.0.5"
+      }
+    },
+    "n64": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/n64/-/n64-0.2.10.tgz",
+      "integrity": "sha512-uH9geV4+roR1tohsrrqSOLCJ9Mh1iFcDI+9vUuydDlDxUS1UCAWUfuGb06p3dj3flzywquJNrGsQ7lHP8+4RVQ=="
+    },
+    "unbound": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/unbound/-/unbound-0.4.3.tgz",
+      "integrity": "sha512-2ISqZLXtzp1l9f1V8Yr6S+zuhXxEwE1CjKHjXULFDHJcfhc9Gm3mn19hdPp4rlNGEdCivKYGKjYe3WRGnafYdA==",
+      "optional": true,
+      "requires": {
+        "loady": "~0.0.5"
+      }
+    },
+    "urkel": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/urkel/-/urkel-0.7.0.tgz",
+      "integrity": "sha512-7Z3Gor4DkKKi0Ehp6H9xehWXqyL12+PA4JM41dcVc1LWks4zI4PGWv6DWgxaLCC+otpEuGdq3Vh5ayD/Mvzfbg==",
+      "requires": {
+        "bfile": "~0.2.1",
+        "bmutex": "~0.1.6",
+        "bsert": "~0.0.10"
+      }
+    }
+  }
+}

--- a/test/integration/package.json
+++ b/test/integration/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "hnsd_integration_test",
+  "version": "1.0.0",
+  "description": "hnsd integration test",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "bmocha": "^2.1.5",
+    "bsert": "0.0.10",
+    "hsd": "^3.0.1"
+  }
+}


### PR DESCRIPTION
Refactored out of bloated #76

Sets up a CI test for end to end integration:

- install nodejs, hsd, bmocha
- instantiate hsd full node, add blocks, win auctions, fill Urkel with DNS records
- spawn hnsd (freshly built by previous CI step)
- connect hnsd to hsd
- make DNS requests to hnsd using a stub resolver in `bns`

These tests SHOULD all fail right now, because they were written to cover #83 #84 and #86. Once those are merged, I'll rebase this and we should see it all pass.

TODO:
- [ ] document how to run the test
- [ ] make the test easier to run from root directory with one command (?)
- [ ] on CI maybe install bmocha globally and clean this up: `./node_modules/bmocha/bin/bmocha --reporter spec hnsd-integration-test.js`