### PR TITLE
Fix Docker build failed + Reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM alpine AS base
+FROM alpine AS build
 COPY . /
 
-FROM base AS build
 RUN apk add --no-cache \
   build-base \
   bash \
@@ -11,7 +10,7 @@ RUN apk add --no-cache \
   unbound-dev
 RUN ./autogen.sh && ./configure && make
 
-FROM base
+FROM alpine
 RUN apk add --no-cache unbound-libs
 COPY --from=build /hnsd /usr/local/bin/hnsd
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY . /
 FROM base AS build
 RUN apk add --no-cache \
   build-base \
-  git \
+  bash \
   automake \
   autoconf \
   libtool \


### PR DESCRIPTION
Building from Dockerfile gives the following error

```
...
> [build 2/2] RUN ./autogen.sh && ./configure && make:                                                                                               
#9 0.381 /bin/sh: ./autogen.sh: not found                                                                                                             
...
```

Alpine Linux doesn't have `/bin/bash` which is the shebang in ./autogen.sh

Also removing `git` since it's not used and removing source files from final build image