### PR TITLE
update openwrt Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,12 +286,12 @@ $ docker stop hnsd
 ### OpenWRT
 
 To build hnsd as an OpenWRT package you'll need to rename `openwrt_Makefile` to `Makefile` 
-and put it in `your_openwrt_dir/package/net/hnsd` before building.
+and put it in `your_openwrt_dir/feeds/package/net/hnsd` before building.
 Then you can use your `menuconfig` and select it.  
 Or you can use this command if you want to build on your SDK this package only:
 
 ```bash
-$ make package/net/hnsd/compile V=s
+$ make package/hnsd/compile V=s
 ```
 
 Please keep in mind that `hnsd` needs `libunbound` and all of its dependencies

--- a/openwrt_Makefile
+++ b/openwrt_Makefile
@@ -25,7 +25,7 @@ PKG_SOURCE_URL:=https://github.com/handshake-org/hnsd/archive/refs/tags
 PKG_HASH:=c2fe479d26e1ea827bbbe091f3308ddb65f9f9a15bb44e1dbda4cee41cfb46a0
 
 PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
-PKG_BUILD_DEPENDS:=libunbound libuv
+PKG_BUILD_DEPENDS:=libuv
 
 PKG_LICENSE:=MIT
 PKG_LICENSE_FILES:=LICENSE
@@ -35,9 +35,15 @@ PKG_BUILD_PARALLEL:=1
 
 include $(INCLUDE_DIR)/package.mk
 
+TARGET_CCASFLAGS = -g
+TARGET_CFLAGS = -Wall -Wno-unused-function -std=gnu11
+TARGET_CFLAGS_FOR_BUILD = -g
+TARGET_CXXFLAGS = -g
+TARGET_libhsk_la_CFLAGS = -DHSK_BUILD -g
+
 define Package/hnsd
   SECTION:=net
-  CATEGORY:=Network 
+  CATEGORY:=Network
   TITLE:=hnsd
   URL:=https://handshake.org/
   DEPENDS:=+libunbound


### PR DESCRIPTION
This disables compiling with -O2 flag since it breaks cross-compiling with at least the MIPS architecture.

Optimizations should be safe to re-enable when the build is fixed to handle COPTS compile flags correctly.