### PR TITLE
Organize unit tests and add integration tests with hsd

### DIFF
--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Integration
         uses: actions/setup-node@v3.5.1
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Integration Tests
         working-directory: ./integration

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -1,4 +1,4 @@
-name: Test - Windows
+name: Test
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 jobs:
-  build:
+  build-windows-latest:
     runs-on: windows-latest
     defaults:
       run:
@@ -17,6 +17,7 @@ jobs:
       - uses: msys2/setup-msys2@v2
         with:
           msystem: MINGW64
+          path-type: inherit
           update: true
           install: git mingw-w64-x86_64-toolchain base-devel mingw-w64-x86_64-unbound autotools
 
@@ -26,9 +27,18 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: Build
-        run: ./autogen.sh && ./configure && make
+        run: ./autogen.sh && ./configure --with-network=regtest && make
 
       - name: Unit Tests
         run: ./test_hnsd
 
-    # TODO: Install nodejs, intall hsd and test end-to-end integration.
+      - name: Setup Integration
+        uses: actions/setup-node@v3.5.1
+        with:
+          node-version: 16
+
+      - name: Integration Tests
+        working-directory: ./integration
+        run:  |
+              npm install
+              npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,9 +25,18 @@ jobs:
         run: sudo apt-get install -y libunbound-dev
 
       - name: Build
-        run: ./autogen.sh && ./configure && make
+        run: ./autogen.sh && ./configure --with-network=regtest && make
 
       - name: Unit Tests
         run: ./test_hnsd
 
-      # TODO: Install nodejs, intall hsd and test end-to-end integration.
+      - name: Setup Integration
+        uses: actions/setup-node@v3.5.1
+        with:
+          node-version: 16
+
+      - name: Integration Tests
+        working-directory: ./integration
+        run: |
+          npm install
+          npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup Integration
         uses: actions/setup-node@v3.5.1
         with:
-          node-version: 16
+          node-version: 18
 
       - name: Integration Tests
         working-directory: ./integration

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ m4/ltversion.m4
 m4/lt~obsolete.m4
 src/stamp-h1
 test_hnsd
+integration/node_modules/

--- a/Makefile.am
+++ b/Makefile.am
@@ -77,7 +77,9 @@ hnsd_CPPFLAGS = $(AM_CPPFLAGS)
 
 noinst_PROGRAMS = test_hnsd
 
-test_hnsd_SOURCES = test/hnsd-test.c
+test_hnsd_SOURCES = test/hnsd-test.c     \
+                    test/base32-test.c   \
+                    test/resource-test.c
 
 test_hnsd_LDFLAGS = -static
 test_hnsd_CPPFLAGS = $(AM_CPPFLAGS)

--- a/Makefile.am
+++ b/Makefile.am
@@ -89,3 +89,8 @@ test_hnsd_LDADD = $(LIB_UNBOUND)             \
 
 # pkgconfigdir = $(libdir)/pkgconfig
 # pkgconfig_DATA = @PACKAGE_NAME@.pc
+
+.PHONY: e2e
+e2e:
+	npm --prefix ./integration/ install
+	npm --prefix ./integration/ run test

--- a/README.md
+++ b/README.md
@@ -345,9 +345,23 @@ $ hnsd [options]
 
 ## Testing
 
+### Unit tests
+
 The `make` command will output two binaries into the root directory: `hnsd`
 and `test_hnsd`, which is compiled from unit tests in the `test/` directory.
 Run the tests with `./test_hnsd`.
+
+### Integration tests
+
+The `integration/` directory contains a nodejs package that installs hsd and
+runs a bmocha test suite. `hnsd` is run using `child_process.spawn()` and tested
+by making DNS queries to its open ports.
+
+```
+cd integration
+npm install
+npm run test
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ by making DNS queries to its open ports.
 Build and run the integration tests (requires nodejs >= v16):
 
 ```
-npm install ./integration
+npm --prefix ./integration install
 npm --prefix ./integration run test
 ```
 

--- a/README.md
+++ b/README.md
@@ -357,10 +357,13 @@ The `integration/` directory contains a nodejs package that installs hsd and
 runs a bmocha test suite. `hnsd` is run using `child_process.spawn()` and tested
 by making DNS queries to its open ports.
 
+`hnsd` MUST be built in regtest mode: `./configure --with-network=regtest`
+
+Build and run the integration tests (requires nodejs >= v16):
+
 ```
-cd integration
-npm install
-npm run test
+npm install ./integration
+npm --prefix ./integration run test
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -362,6 +362,12 @@ by making DNS queries to its open ports.
 Build and run the integration tests (requires nodejs >= v16):
 
 ```
+make e2e
+```
+
+or:
+
+```
 npm --prefix ./integration install
 npm --prefix ./integration run test
 ```

--- a/integration/package-lock.json
+++ b/integration/package-lock.json
@@ -1,0 +1,798 @@
+{
+  "name": "hnsd_integration_test",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hnsd_integration_test",
+      "dependencies": {
+        "bmocha": "^2.1.5",
+        "bsert": "0.0.10",
+        "hsd": "^4.0.1"
+      }
+    },
+    "node_modules/bcfg": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/bcfg/-/bcfg-0.1.7.tgz",
+      "integrity": "sha512-+4beq5bXwfmxdcEoHYQsaXawh1qFzjLcRvPe5k5ww/NEWzZTm56Jk8LuPmfeGB7X584jZ8xGq6UgMaZnNDa5Ww==",
+      "dependencies": {
+        "bsert": "~0.0.10"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/bcrypto": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-5.4.0.tgz",
+      "integrity": "sha512-KDX2CR29o6ZoqpQndcCxFZAtYA1jDMnXU3jmCfzP44g++Cu7AHHtZN/JbrN/MXAg9SLvtQ8XISG+eVD9zH1+Jg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "bufio": "~1.0.7",
+        "loady": "~0.0.5"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/bcurl": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/bcurl/-/bcurl-0.2.0.tgz",
+      "integrity": "sha512-uBWc/w3AqjAfo6/+ODoRSoY/w/C7UaU/9AYcXjxgObTyUf3lvV5jCuAU/dSZyWysDyWBQkPzllOd7KZkwJHnwg==",
+      "dependencies": {
+        "brq": "~0.1.8",
+        "bsert": "~0.0.10",
+        "bsock": "~0.1.9"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/bdb": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/bdb/-/bdb-1.4.0.tgz",
+      "integrity": "sha512-NjsvznNQSW419u/VlitEioAglJd44n6MrOI+6Rf9JqlyF6DQytBh8bwCT3axUw095aUlGtvoscJG3C56pIPQ7Q==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "bsert": "~0.0.10",
+        "loady": "~0.0.5"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/bdns": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/bdns/-/bdns-0.1.5.tgz",
+      "integrity": "sha512-LNVkfM7ynlAD0CvPvO9cKxW8YXt1KOCRQZlRsGZWeMyymUWVdHQpZudAzH9chaFAz6HiwAnQxwDemCKDPy6Mag==",
+      "dependencies": {
+        "bsert": "~0.0.10"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/bevent": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/bevent/-/bevent-0.1.5.tgz",
+      "integrity": "sha512-hs6T3BjndibrAmPSoKTHmKa3tz/c6Qgjv9iZw+tAoxuP6izfTCkzfltBQrW7SuK5xnY22gv9jCEf51+mRH+Qvg==",
+      "dependencies": {
+        "bsert": "~0.0.10"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/bfile": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/bfile/-/bfile-0.2.2.tgz",
+      "integrity": "sha512-X205SsJ7zFAnjeJ/pBLqDqF10x/4Su3pBy8UdVKw4hdGJk7t5pLoRi+uG4rPaDAClGbrEfT/06PGUbYiMYKzTg==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/bfilter": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/bfilter/-/bfilter-1.0.5.tgz",
+      "integrity": "sha512-GupIidtCvLbKhXnA1sxvrwa+gh95qbjafy7P1U1x/2DHxNabXq4nGW0x3rmgzlJMYlVl+c8fMxoMRIwpKYlgcQ==",
+      "dependencies": {
+        "bsert": "~0.0.10",
+        "bufio": "~1.0.6",
+        "mrmr": "~0.1.6"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/bheep": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/bheep/-/bheep-0.1.5.tgz",
+      "integrity": "sha512-0KR5Zi8hgJBKL35+aYzndCTtgSGakOMxrYw2uszd5UmXTIfx3+drPGoETlVbQ6arTdAzSoQYA1j35vbaWpQXBg==",
+      "dependencies": {
+        "bsert": "~0.0.10"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/binet": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/binet/-/binet-0.3.7.tgz",
+      "integrity": "sha512-GF+QD4ajs3GWabaVzso7Kn9aZEbwI0e54FKU2ID8bM/7rIk7BpSJytB1KS7SMpix+fWAi9MAGkOgSFljl0aaKg==",
+      "dependencies": {
+        "bs32": "~0.1.5",
+        "bsert": "~0.0.10"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/blgr": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/blgr/-/blgr-0.2.0.tgz",
+      "integrity": "sha512-2jZdqajYCGD5rwGdOooQpxgjKsiAAV2g8LapwSnbTjAYTZAqmqBAS+GsVGFi+/y7t1Pspidv/5HsWBbJrsEuFw==",
+      "dependencies": {
+        "bsert": "~0.0.10"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/blru": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/blru/-/blru-0.1.6.tgz",
+      "integrity": "sha512-34+xZ2u4ys/aUzWCU9m6Eee4nVuN1ywdxbi8b3Z2WULU6qvnfeHvCWEdGzlVfRbbhimG2xxJX6R77GD2cuVO6w==",
+      "dependencies": {
+        "bsert": "~0.0.10"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/blst": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/blst/-/blst-0.1.5.tgz",
+      "integrity": "sha512-TPl04Cx3CHdPFAJ2x9Xx1Z1FOfpAzmNPfHkfo+pGAaNH4uLhS58ExvamVkZh3jadF+B7V5sMtqvrqdf9mHINYA==",
+      "dependencies": {
+        "bsert": "~0.0.10"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/bmocha": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/bmocha/-/bmocha-2.1.7.tgz",
+      "integrity": "sha512-JaNhxnynduQzVbG+8Q9ojlrGlpJXG7Cu+yyPx5OHd0dy1Rh759PmWegyipPAG0UQzBxucDvt0M9vgWHSv7KZ9w==",
+      "bin": {
+        "_bmocha": "bin/_bmocha",
+        "bmocha": "bin/bmocha"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/bmutex": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bmutex/-/bmutex-0.1.6.tgz",
+      "integrity": "sha512-nXWOXtQHbfPaMl6jyEF/rmRMrcemj2qn+OCAI/uZYurjfx7Dg3baoXdPzHOL0U8Cfvn8CWxKcnM/rgxL7DR4zw==",
+      "dependencies": {
+        "bsert": "~0.0.10"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/bns": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/bns/-/bns-0.15.0.tgz",
+      "integrity": "sha512-iJWQVE399vQzPfhalFMJGEQ7k5Ot2D6Mz8dkoPeLO8huWAMOiJNJ1tHzOu5j+ZyNNew6ITgG/LsSyaRPxvkXuw==",
+      "dependencies": {
+        "bcrypto": "~5.4.0",
+        "bfile": "~0.2.2",
+        "bheep": "~0.1.5",
+        "binet": "~0.3.6",
+        "bs32": "~0.1.6",
+        "bsert": "~0.0.10",
+        "btcp": "~0.1.5",
+        "budp": "~0.1.6",
+        "bufio": "~1.0.7"
+      },
+      "bin": {
+        "bns-keygen": "bin/bns-keygen",
+        "bns-prove": "bin/bns-prove",
+        "dig.js": "bin/dig.js",
+        "dig2json": "bin/dig2json",
+        "json2dig": "bin/json2dig",
+        "json2rr": "bin/json2rr",
+        "json2zone": "bin/json2zone",
+        "named.js": "bin/named.js",
+        "rr2json": "bin/rr2json",
+        "whois.js": "bin/whois.js",
+        "zone2json": "bin/zone2json"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "unbound": "~0.4.3"
+      }
+    },
+    "node_modules/brq": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/brq/-/brq-0.1.8.tgz",
+      "integrity": "sha512-6SDY1lJMKXgt5TZ6voJQMH2zV1XPWWtm203PSkx3DSg9AYNYuRfOPFSBDkNemabzgpzFW9/neR4YhTvyJml8rQ==",
+      "dependencies": {
+        "bsert": "~0.0.10"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/bs32": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bs32/-/bs32-0.1.6.tgz",
+      "integrity": "sha512-usjDesQqZ8ihHXOnOEQuAdymBHnJEfSd+aELFSg1jN/V3iAf12HrylHlRJwIt6DTMmXpBDQ+YBg3Q3DIYdhRgQ==",
+      "dependencies": {
+        "bsert": "~0.0.10"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/bsert": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.10.tgz",
+      "integrity": "sha512-NHNwlac+WPy4t2LoNh8pXk8uaIGH3NSaIUbTTRXGpE2WEbq0te/tDykYHkFK57YKLPjv/aGHmbqvnGeVWDz57Q==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/bsock": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/bsock/-/bsock-0.1.9.tgz",
+      "integrity": "sha512-/l9Kg/c5o+n/0AqreMxh2jpzDMl1ikl4gUxT7RFNe3A3YRIyZkiREhwcjmqxiymJSRI/Qhew357xGn1SLw/xEw==",
+      "dependencies": {
+        "bsert": "~0.0.10"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/bsocks": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bsocks/-/bsocks-0.2.6.tgz",
+      "integrity": "sha512-66UkjoB9f7lhT+WKgYq8MQa6nkr96mlX64JYMlIsXe/X4VeqNwvsx7UOE3ZqD6lkwg8GvBhapRTWj0qWO3Pw8w==",
+      "dependencies": {
+        "binet": "~0.3.5",
+        "bsert": "~0.0.10"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/btcp": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/btcp/-/btcp-0.1.5.tgz",
+      "integrity": "sha512-tkrtMDxeJorn5p0KxaLXELneT8AbfZMpOFeoKYZ5qCCMMSluNuwut7pGccLC5YOJqmuk0DR774vNVQLC9sNq/A==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/budp": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/budp/-/budp-0.1.6.tgz",
+      "integrity": "sha512-o+a8NPq3DhV91j4nInjht2md6mbU1XL+7ciPltP66rw5uD3KP1m5r8lA94LZVaPKcFdJ0l2HVVzRNxnY26Pefg==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/buffer-map": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buffer-map/-/buffer-map-0.0.7.tgz",
+      "integrity": "sha512-95try3p/vMRkIAAnJDaGkFhGpT/65NoeW6XelEPjAomWYR58RQtW4khn0SwKj34kZoE7uxL7w2koZSwbnszvQQ==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/bufio": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.7.tgz",
+      "integrity": "sha512-bd1dDQhiC+bEbEfg56IdBv7faWa6OipMs/AFFFvtFnB3wAYjlwQpQRZ0pm6ZkgtfL0pILRXhKxOiQj6UzoMR7A==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/bupnp": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bupnp/-/bupnp-0.2.6.tgz",
+      "integrity": "sha512-J6ykzJhZMxXKN78K+1NzFi3v/51X2Mvzp2hW42BWwmxIVfau6PaN99gyABZ8x05e8MObWbsAis23gShhj9qpbw==",
+      "dependencies": {
+        "binet": "~0.3.5",
+        "brq": "~0.1.7",
+        "bsert": "~0.0.10"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/bval": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bval/-/bval-0.1.6.tgz",
+      "integrity": "sha512-jxNH9gSx7g749hQtS+nTxXYz/bLxwr4We1RHFkCYalNYcj12RfbW6qYWsKu0RYiKAdFcbNoZRHmWrIuXIyhiQQ==",
+      "dependencies": {
+        "bsert": "~0.0.10"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/bweb": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/bweb/-/bweb-0.1.10.tgz",
+      "integrity": "sha512-3Kkz/rfsyAWUS+8DV5XYhwcgVN4DfDewrP+iFTcpQfdZzcF6+OypAq7dHOtXV0sW7U/3msA/sEEqz0MHZ9ERWg==",
+      "dependencies": {
+        "bsert": "~0.0.10",
+        "bsock": "~0.1.8"
+      },
+      "bin": {
+        "bweb": "bin/bweb"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/goosig": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/goosig/-/goosig-0.10.0.tgz",
+      "integrity": "sha512-+BVVLfxmawAmGVjjJpXzu5LNcFIOfgXgP7kWEyc3qu/xn9RMqbPbNfYDdHBZKfZkDMIO7Q4vD790iNYQAXhoFA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "bcrypto": "~5.4.0",
+        "bsert": "~0.0.10",
+        "loady": "~0.0.5"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/hs-client": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/hs-client/-/hs-client-0.0.11.tgz",
+      "integrity": "sha512-DunENysXNxADDs6YvTjIgFG38U+mGnlDpfEhUzHOAOnkHyYwAIm0PwYJEmJqsbLnpY31xg0lPfRV8t+Ugz+Dew==",
+      "dependencies": {
+        "bcfg": "~0.1.7",
+        "bcurl": "~0.2.0",
+        "bsert": "~0.0.10"
+      },
+      "bin": {
+        "hsd-cli": "bin/hsd-cli",
+        "hsd-rpc": "bin/hsd-rpc",
+        "hsw-cli": "bin/hsw-cli",
+        "hsw-rpc": "bin/hsw-rpc"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/hsd": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/hsd/-/hsd-4.0.1.tgz",
+      "integrity": "sha512-5kb4Cp3/XjrFLmUZxl0tQxqVfmFxfrfys1sT9jmUK/Aq/tw+6/GkRGJjgrdTuzRL48zLrczOwL7/Q2e3Ufg2vA==",
+      "dependencies": {
+        "bcfg": "~0.1.7",
+        "bcrypto": "~5.4.0",
+        "bdb": "~1.4.0",
+        "bdns": "~0.1.5",
+        "bevent": "~0.1.5",
+        "bfile": "~0.2.2",
+        "bfilter": "~1.0.5",
+        "bheep": "~0.1.5",
+        "binet": "~0.3.7",
+        "blgr": "~0.2.0",
+        "blru": "~0.1.6",
+        "blst": "~0.1.5",
+        "bmutex": "~0.1.6",
+        "bns": "~0.15.0",
+        "bsert": "~0.0.10",
+        "bsock": "~0.1.9",
+        "bsocks": "~0.2.6",
+        "btcp": "~0.1.5",
+        "buffer-map": "~0.0.7",
+        "bufio": "~1.0.7",
+        "bupnp": "~0.2.6",
+        "bval": "~0.1.6",
+        "bweb": "~0.1.10",
+        "goosig": "~0.10.0",
+        "hs-client": "~0.0.11",
+        "n64": "~0.2.10",
+        "urkel": "~1.0.2"
+      },
+      "bin": {
+        "hs-seeder": "bin/hs-seeder",
+        "hs-wallet": "bin/hsw",
+        "hsd": "bin/hsd",
+        "hsd-cli": "bin/hsd-cli",
+        "hsd-node": "bin/node",
+        "hsd-spvnode": "bin/spvnode",
+        "hsw-cli": "bin/hsw-cli"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/loady": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/loady/-/loady-0.0.5.tgz",
+      "integrity": "sha512-uxKD2HIj042/HBx77NBcmEPsD+hxCgAtjEWlYNScuUjIsh/62Uyu39GOR68TBR68v+jqDL9zfftCWoUo4y03sQ==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/mrmr": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/mrmr/-/mrmr-0.1.10.tgz",
+      "integrity": "sha512-NJRJs+yJyRWwcTqLRf7O32n56UP1+UQoTrGVEoB3LMj0h2jlon790drDbxKvi5mK5k4HfC0cpNkxqHcrJK/evg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "bsert": "~0.0.10",
+        "loady": "~0.0.5"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/n64": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/n64/-/n64-0.2.10.tgz",
+      "integrity": "sha512-uH9geV4+roR1tohsrrqSOLCJ9Mh1iFcDI+9vUuydDlDxUS1UCAWUfuGb06p3dj3flzywquJNrGsQ7lHP8+4RVQ==",
+      "engines": {
+        "node": ">=2.0.0"
+      }
+    },
+    "node_modules/unbound": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/unbound/-/unbound-0.4.3.tgz",
+      "integrity": "sha512-2ISqZLXtzp1l9f1V8Yr6S+zuhXxEwE1CjKHjXULFDHJcfhc9Gm3mn19hdPp4rlNGEdCivKYGKjYe3WRGnafYdA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "loady": "~0.0.5"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/urkel": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/urkel/-/urkel-1.0.2.tgz",
+      "integrity": "sha512-Y5UXbgBr6pczrD08N0SYJkWjtdtTTpmZsOvuftdrEHLnTjuxwSNjKsXYLQkICTptvnHAJ2OjI6XdAxtYTyOHew==",
+      "dependencies": {
+        "bfile": "~0.2.1",
+        "bmutex": "~0.1.6",
+        "bsert": "~0.0.10"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    }
+  },
+  "dependencies": {
+    "bcfg": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/bcfg/-/bcfg-0.1.7.tgz",
+      "integrity": "sha512-+4beq5bXwfmxdcEoHYQsaXawh1qFzjLcRvPe5k5ww/NEWzZTm56Jk8LuPmfeGB7X584jZ8xGq6UgMaZnNDa5Ww==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bcrypto": {
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/bcrypto/-/bcrypto-5.4.0.tgz",
+      "integrity": "sha512-KDX2CR29o6ZoqpQndcCxFZAtYA1jDMnXU3jmCfzP44g++Cu7AHHtZN/JbrN/MXAg9SLvtQ8XISG+eVD9zH1+Jg==",
+      "requires": {
+        "bufio": "~1.0.7",
+        "loady": "~0.0.5"
+      }
+    },
+    "bcurl": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/bcurl/-/bcurl-0.2.0.tgz",
+      "integrity": "sha512-uBWc/w3AqjAfo6/+ODoRSoY/w/C7UaU/9AYcXjxgObTyUf3lvV5jCuAU/dSZyWysDyWBQkPzllOd7KZkwJHnwg==",
+      "requires": {
+        "brq": "~0.1.8",
+        "bsert": "~0.0.10",
+        "bsock": "~0.1.9"
+      }
+    },
+    "bdb": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/bdb/-/bdb-1.4.0.tgz",
+      "integrity": "sha512-NjsvznNQSW419u/VlitEioAglJd44n6MrOI+6Rf9JqlyF6DQytBh8bwCT3axUw095aUlGtvoscJG3C56pIPQ7Q==",
+      "requires": {
+        "bsert": "~0.0.10",
+        "loady": "~0.0.5"
+      }
+    },
+    "bdns": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/bdns/-/bdns-0.1.5.tgz",
+      "integrity": "sha512-LNVkfM7ynlAD0CvPvO9cKxW8YXt1KOCRQZlRsGZWeMyymUWVdHQpZudAzH9chaFAz6HiwAnQxwDemCKDPy6Mag==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bevent": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/bevent/-/bevent-0.1.5.tgz",
+      "integrity": "sha512-hs6T3BjndibrAmPSoKTHmKa3tz/c6Qgjv9iZw+tAoxuP6izfTCkzfltBQrW7SuK5xnY22gv9jCEf51+mRH+Qvg==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bfile": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/bfile/-/bfile-0.2.2.tgz",
+      "integrity": "sha512-X205SsJ7zFAnjeJ/pBLqDqF10x/4Su3pBy8UdVKw4hdGJk7t5pLoRi+uG4rPaDAClGbrEfT/06PGUbYiMYKzTg=="
+    },
+    "bfilter": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/bfilter/-/bfilter-1.0.5.tgz",
+      "integrity": "sha512-GupIidtCvLbKhXnA1sxvrwa+gh95qbjafy7P1U1x/2DHxNabXq4nGW0x3rmgzlJMYlVl+c8fMxoMRIwpKYlgcQ==",
+      "requires": {
+        "bsert": "~0.0.10",
+        "bufio": "~1.0.6",
+        "mrmr": "~0.1.6"
+      }
+    },
+    "bheep": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/bheep/-/bheep-0.1.5.tgz",
+      "integrity": "sha512-0KR5Zi8hgJBKL35+aYzndCTtgSGakOMxrYw2uszd5UmXTIfx3+drPGoETlVbQ6arTdAzSoQYA1j35vbaWpQXBg==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "binet": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/binet/-/binet-0.3.7.tgz",
+      "integrity": "sha512-GF+QD4ajs3GWabaVzso7Kn9aZEbwI0e54FKU2ID8bM/7rIk7BpSJytB1KS7SMpix+fWAi9MAGkOgSFljl0aaKg==",
+      "requires": {
+        "bs32": "~0.1.5",
+        "bsert": "~0.0.10"
+      }
+    },
+    "blgr": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/blgr/-/blgr-0.2.0.tgz",
+      "integrity": "sha512-2jZdqajYCGD5rwGdOooQpxgjKsiAAV2g8LapwSnbTjAYTZAqmqBAS+GsVGFi+/y7t1Pspidv/5HsWBbJrsEuFw==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "blru": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/blru/-/blru-0.1.6.tgz",
+      "integrity": "sha512-34+xZ2u4ys/aUzWCU9m6Eee4nVuN1ywdxbi8b3Z2WULU6qvnfeHvCWEdGzlVfRbbhimG2xxJX6R77GD2cuVO6w==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "blst": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/blst/-/blst-0.1.5.tgz",
+      "integrity": "sha512-TPl04Cx3CHdPFAJ2x9Xx1Z1FOfpAzmNPfHkfo+pGAaNH4uLhS58ExvamVkZh3jadF+B7V5sMtqvrqdf9mHINYA==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bmocha": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/bmocha/-/bmocha-2.1.7.tgz",
+      "integrity": "sha512-JaNhxnynduQzVbG+8Q9ojlrGlpJXG7Cu+yyPx5OHd0dy1Rh759PmWegyipPAG0UQzBxucDvt0M9vgWHSv7KZ9w=="
+    },
+    "bmutex": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bmutex/-/bmutex-0.1.6.tgz",
+      "integrity": "sha512-nXWOXtQHbfPaMl6jyEF/rmRMrcemj2qn+OCAI/uZYurjfx7Dg3baoXdPzHOL0U8Cfvn8CWxKcnM/rgxL7DR4zw==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bns": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/bns/-/bns-0.15.0.tgz",
+      "integrity": "sha512-iJWQVE399vQzPfhalFMJGEQ7k5Ot2D6Mz8dkoPeLO8huWAMOiJNJ1tHzOu5j+ZyNNew6ITgG/LsSyaRPxvkXuw==",
+      "requires": {
+        "bcrypto": "~5.4.0",
+        "bfile": "~0.2.2",
+        "bheep": "~0.1.5",
+        "binet": "~0.3.6",
+        "bs32": "~0.1.6",
+        "bsert": "~0.0.10",
+        "btcp": "~0.1.5",
+        "budp": "~0.1.6",
+        "bufio": "~1.0.7",
+        "unbound": "~0.4.3"
+      }
+    },
+    "brq": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/brq/-/brq-0.1.8.tgz",
+      "integrity": "sha512-6SDY1lJMKXgt5TZ6voJQMH2zV1XPWWtm203PSkx3DSg9AYNYuRfOPFSBDkNemabzgpzFW9/neR4YhTvyJml8rQ==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bs32": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bs32/-/bs32-0.1.6.tgz",
+      "integrity": "sha512-usjDesQqZ8ihHXOnOEQuAdymBHnJEfSd+aELFSg1jN/V3iAf12HrylHlRJwIt6DTMmXpBDQ+YBg3Q3DIYdhRgQ==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bsert": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/bsert/-/bsert-0.0.10.tgz",
+      "integrity": "sha512-NHNwlac+WPy4t2LoNh8pXk8uaIGH3NSaIUbTTRXGpE2WEbq0te/tDykYHkFK57YKLPjv/aGHmbqvnGeVWDz57Q=="
+    },
+    "bsock": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/bsock/-/bsock-0.1.9.tgz",
+      "integrity": "sha512-/l9Kg/c5o+n/0AqreMxh2jpzDMl1ikl4gUxT7RFNe3A3YRIyZkiREhwcjmqxiymJSRI/Qhew357xGn1SLw/xEw==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bsocks": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bsocks/-/bsocks-0.2.6.tgz",
+      "integrity": "sha512-66UkjoB9f7lhT+WKgYq8MQa6nkr96mlX64JYMlIsXe/X4VeqNwvsx7UOE3ZqD6lkwg8GvBhapRTWj0qWO3Pw8w==",
+      "requires": {
+        "binet": "~0.3.5",
+        "bsert": "~0.0.10"
+      }
+    },
+    "btcp": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/btcp/-/btcp-0.1.5.tgz",
+      "integrity": "sha512-tkrtMDxeJorn5p0KxaLXELneT8AbfZMpOFeoKYZ5qCCMMSluNuwut7pGccLC5YOJqmuk0DR774vNVQLC9sNq/A=="
+    },
+    "budp": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/budp/-/budp-0.1.6.tgz",
+      "integrity": "sha512-o+a8NPq3DhV91j4nInjht2md6mbU1XL+7ciPltP66rw5uD3KP1m5r8lA94LZVaPKcFdJ0l2HVVzRNxnY26Pefg=="
+    },
+    "buffer-map": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/buffer-map/-/buffer-map-0.0.7.tgz",
+      "integrity": "sha512-95try3p/vMRkIAAnJDaGkFhGpT/65NoeW6XelEPjAomWYR58RQtW4khn0SwKj34kZoE7uxL7w2koZSwbnszvQQ=="
+    },
+    "bufio": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/bufio/-/bufio-1.0.7.tgz",
+      "integrity": "sha512-bd1dDQhiC+bEbEfg56IdBv7faWa6OipMs/AFFFvtFnB3wAYjlwQpQRZ0pm6ZkgtfL0pILRXhKxOiQj6UzoMR7A=="
+    },
+    "bupnp": {
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/bupnp/-/bupnp-0.2.6.tgz",
+      "integrity": "sha512-J6ykzJhZMxXKN78K+1NzFi3v/51X2Mvzp2hW42BWwmxIVfau6PaN99gyABZ8x05e8MObWbsAis23gShhj9qpbw==",
+      "requires": {
+        "binet": "~0.3.5",
+        "brq": "~0.1.7",
+        "bsert": "~0.0.10"
+      }
+    },
+    "bval": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/bval/-/bval-0.1.6.tgz",
+      "integrity": "sha512-jxNH9gSx7g749hQtS+nTxXYz/bLxwr4We1RHFkCYalNYcj12RfbW6qYWsKu0RYiKAdFcbNoZRHmWrIuXIyhiQQ==",
+      "requires": {
+        "bsert": "~0.0.10"
+      }
+    },
+    "bweb": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/bweb/-/bweb-0.1.10.tgz",
+      "integrity": "sha512-3Kkz/rfsyAWUS+8DV5XYhwcgVN4DfDewrP+iFTcpQfdZzcF6+OypAq7dHOtXV0sW7U/3msA/sEEqz0MHZ9ERWg==",
+      "requires": {
+        "bsert": "~0.0.10",
+        "bsock": "~0.1.8"
+      }
+    },
+    "goosig": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/goosig/-/goosig-0.10.0.tgz",
+      "integrity": "sha512-+BVVLfxmawAmGVjjJpXzu5LNcFIOfgXgP7kWEyc3qu/xn9RMqbPbNfYDdHBZKfZkDMIO7Q4vD790iNYQAXhoFA==",
+      "requires": {
+        "bcrypto": "~5.4.0",
+        "bsert": "~0.0.10",
+        "loady": "~0.0.5"
+      }
+    },
+    "hs-client": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/hs-client/-/hs-client-0.0.11.tgz",
+      "integrity": "sha512-DunENysXNxADDs6YvTjIgFG38U+mGnlDpfEhUzHOAOnkHyYwAIm0PwYJEmJqsbLnpY31xg0lPfRV8t+Ugz+Dew==",
+      "requires": {
+        "bcfg": "~0.1.7",
+        "bcurl": "~0.2.0",
+        "bsert": "~0.0.10"
+      }
+    },
+    "hsd": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/hsd/-/hsd-4.0.1.tgz",
+      "integrity": "sha512-5kb4Cp3/XjrFLmUZxl0tQxqVfmFxfrfys1sT9jmUK/Aq/tw+6/GkRGJjgrdTuzRL48zLrczOwL7/Q2e3Ufg2vA==",
+      "requires": {
+        "bcfg": "~0.1.7",
+        "bcrypto": "~5.4.0",
+        "bdb": "~1.4.0",
+        "bdns": "~0.1.5",
+        "bevent": "~0.1.5",
+        "bfile": "~0.2.2",
+        "bfilter": "~1.0.5",
+        "bheep": "~0.1.5",
+        "binet": "~0.3.7",
+        "blgr": "~0.2.0",
+        "blru": "~0.1.6",
+        "blst": "~0.1.5",
+        "bmutex": "~0.1.6",
+        "bns": "~0.15.0",
+        "bsert": "~0.0.10",
+        "bsock": "~0.1.9",
+        "bsocks": "~0.2.6",
+        "btcp": "~0.1.5",
+        "buffer-map": "~0.0.7",
+        "bufio": "~1.0.7",
+        "bupnp": "~0.2.6",
+        "bval": "~0.1.6",
+        "bweb": "~0.1.10",
+        "goosig": "~0.10.0",
+        "hs-client": "~0.0.11",
+        "n64": "~0.2.10",
+        "urkel": "~1.0.2"
+      }
+    },
+    "loady": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/loady/-/loady-0.0.5.tgz",
+      "integrity": "sha512-uxKD2HIj042/HBx77NBcmEPsD+hxCgAtjEWlYNScuUjIsh/62Uyu39GOR68TBR68v+jqDL9zfftCWoUo4y03sQ=="
+    },
+    "mrmr": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/mrmr/-/mrmr-0.1.10.tgz",
+      "integrity": "sha512-NJRJs+yJyRWwcTqLRf7O32n56UP1+UQoTrGVEoB3LMj0h2jlon790drDbxKvi5mK5k4HfC0cpNkxqHcrJK/evg==",
+      "requires": {
+        "bsert": "~0.0.10",
+        "loady": "~0.0.5"
+      }
+    },
+    "n64": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/n64/-/n64-0.2.10.tgz",
+      "integrity": "sha512-uH9geV4+roR1tohsrrqSOLCJ9Mh1iFcDI+9vUuydDlDxUS1UCAWUfuGb06p3dj3flzywquJNrGsQ7lHP8+4RVQ=="
+    },
+    "unbound": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/unbound/-/unbound-0.4.3.tgz",
+      "integrity": "sha512-2ISqZLXtzp1l9f1V8Yr6S+zuhXxEwE1CjKHjXULFDHJcfhc9Gm3mn19hdPp4rlNGEdCivKYGKjYe3WRGnafYdA==",
+      "optional": true,
+      "requires": {
+        "loady": "~0.0.5"
+      }
+    },
+    "urkel": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/urkel/-/urkel-1.0.2.tgz",
+      "integrity": "sha512-Y5UXbgBr6pczrD08N0SYJkWjtdtTTpmZsOvuftdrEHLnTjuxwSNjKsXYLQkICTptvnHAJ2OjI6XdAxtYTyOHew==",
+      "requires": {
+        "bfile": "~0.2.1",
+        "bmutex": "~0.1.6",
+        "bsert": "~0.0.10"
+      }
+    }
+  }
+}

--- a/integration/package-lock.json
+++ b/integration/package-lock.json
@@ -6,6 +6,7 @@
   "packages": {
     "": {
       "name": "hnsd_integration_test",
+      "version": "1.0.0",
       "dependencies": {
         "bmocha": "^2.1.5",
         "bsert": "0.0.10",

--- a/integration/package.json
+++ b/integration/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "hnsd_integration_test",
+  "scripts": {
+    "test": "bmocha --reporter spec test/*.js",
+    "test-file": "bmocha --reporter spec"
+  },
+  "dependencies": {
+    "bmocha": "^2.1.5",
+    "bsert": "0.0.10",
+    "hsd": "^4.0.1"
+  }
+}

--- a/integration/package.json
+++ b/integration/package.json
@@ -1,5 +1,7 @@
 {
   "name": "hnsd_integration_test",
+  "meta": "!! version must match hnsd version in Makefile.am !!",
+  "version": "1.0.0", 
   "scripts": {
     "test": "bmocha --reporter spec test/*.js",
     "test-file": "bmocha --reporter spec"

--- a/integration/test-util.js
+++ b/integration/test-util.js
@@ -1,16 +1,21 @@
 
 'use strict';
 
-const {spawn} = require('child_process');
+const {spawn, execSync} = require('child_process');
+const assert = require('bsert');
 const path = require('path');
 const {FullNode} = require('hsd');
 const StubResolver = require('bns/lib/resolver/stub');
+const {EOL} = require('os');
+const {version} = require('./package.json');
+const network = 'regtest';
+const hnsdPath = path.join(__dirname, '..', 'hnsd');
 
 class TestUtil {
   constructor() {
     this.node = new FullNode({
       memory: true,
-      network: 'regtest',
+      network,
       listen: true,
       port: 10000,
       noDns: true,
@@ -27,13 +32,20 @@ class TestUtil {
   }
 
   async open() {
+    const hnsdVersion = (await execSync(hnsdPath + ' -v')).toString('ascii');
+    assert.strictEqual(
+      hnsdVersion,
+      `${version} (${network})` + EOL,
+      'Network or version mismatch'
+    );
+
     await this.node.open();
     await this.node.connect();
 
     this.wallet = this.node.plugins.walletdb;
 
     this.hnsd = spawn(
-      path.join(__dirname, '..', 'hnsd'),
+      hnsdPath,
       ['-s', '127.0.0.1:10000']
     );
 

--- a/integration/test-util.js
+++ b/integration/test-util.js
@@ -4,7 +4,7 @@
 const {spawn} = require('child_process');
 const path = require('path');
 const {FullNode} = require('hsd');
-const dns = require('bns/lib/dns');
+const StubResolver = require('bns/lib/resolver/stub');
 
 class TestUtil {
   constructor() {
@@ -19,11 +19,7 @@ class TestUtil {
 
     this.wallet = null;
 
-    this.resolver = new dns.Resolver({
-      host: '127.0.0.1',
-      port: 25349,
-      dnssec: true
-    });
+    this.resolver = new StubResolver();
     this.resolver.setServers(['127.0.0.1:25349']);
 
     this.hnsd = null;

--- a/integration/test-util.js
+++ b/integration/test-util.js
@@ -1,0 +1,114 @@
+
+'use strict';
+
+const {spawn} = require('child_process');
+const path = require('path');
+const {FullNode} = require('hsd');
+const dns = require('bns/lib/dns');
+
+class TestUtil {
+  constructor() {
+    this.node = new FullNode({
+      memory: true,
+      network: 'regtest',
+      listen: true,
+      port: 10000,
+      noDns: true,
+      plugins: [require('hsd/lib/wallet/plugin')]
+    });
+
+    this.wallet = null;
+
+    this.resolver = new dns.Resolver({
+      host: '127.0.0.1',
+      port: 25349,
+      dnssec: true
+    });
+    this.resolver.setServers(['127.0.0.1:25349']);
+
+    this.hnsd = null;
+    this.hnsdHeight = 0;
+  }
+
+  async open() {
+    await this.node.open();
+    await this.node.connect();
+
+    this.wallet = this.node.plugins.walletdb;
+
+    this.hnsd = spawn(
+      path.join(__dirname, '..', 'hnsd'),
+      ['-s', '127.0.0.1:10000']
+    );
+
+    this.hnsd.stdout.on('data', (data) => {
+      // TODO: `data` is always 8192 bytes and output gets cut off, why?
+      const chunk = data.toString('ascii');
+      const lines = chunk.split(/\n/);
+
+      for (const line of lines) {
+        const words = line.split(/\s+/);
+
+        if (words[0] !== 'chain' || words.length < 2)
+          continue;
+
+        this.hnsdHeight = parseInt(words[1].slice(1, -2));
+      }
+    });
+  }
+
+  async close() {
+    this.hnsd.kill('SIGKILL');
+    await this.node.close();
+  }
+
+  async getWalletAddress() {
+    return this.wallet.rpc.getNewAddress(['default']);
+  }
+
+  async generate(n) {
+    const addr = await this.getWalletAddress();
+    await this.node.rpc.generateToAddress([n, addr]);
+  }
+
+  // names: Object with name:records[] mapping
+  async registerNames(names) {
+    for (const name of Object.keys(names)) {
+      await this.wallet.rpc.sendOpen([name]);
+    }
+    await this.generate(6);
+
+    for (const name of Object.keys(names)) {
+      await this.wallet.rpc.sendBid([name, 1, 1]);
+    }
+
+    await this.generate(6);
+    await this.wallet.rpc.sendReveal([]);
+
+    await this.generate(10);
+    for (const name of Object.keys(names)) {
+      await this.wallet.rpc.sendUpdate([name, {records: names[name]}]);
+    }
+    await this.generate(12); // safe root
+  }
+
+  waitForSync() {
+    return new Promise((resolve, reject) => {
+      // Hack
+      setTimeout(() => {
+        resolve();
+      }, 5000);
+
+    // // TODO: Fix hnsd stdout parsing for chain height
+    //   setTimeout(() => {
+    //     reject(new Error('Timeout waiting for sync'));
+    //   }, 5000);
+    //   setInterval(() => {
+    //     if (this.hnsdHeight === this.node.chain.height)
+    //       resolve();
+    //   }, 100);
+    });
+  }
+}
+
+module.exports = TestUtil;

--- a/integration/test/sync-resolve-test.js
+++ b/integration/test/sync-resolve-test.js
@@ -90,7 +90,7 @@ describe('Basic sync & resolve', function() {
   });
 
   it('should resolve DS', async () => {
-    const res = await util.resolver.resolveRaw('test-ds', 'DS');
+    const res = await util.resolver.lookup('test-ds', 'DS');
 
     assert.strictEqual(res.code, wire.codes.NOERROR);
 
@@ -105,7 +105,7 @@ describe('Basic sync & resolve', function() {
   });
 
   it('should resolve NS', async () => {
-    const res = await util.resolver.resolveRaw('test-ns', 'NS');
+    const res = await util.resolver.lookup('test-ns', 'NS');
 
     assert.strictEqual(res.code, wire.codes.NOERROR);
 
@@ -119,7 +119,7 @@ describe('Basic sync & resolve', function() {
   });
 
   it('should resolve TXT', async () => {
-    const res = await util.resolver.resolveRaw('test-txt', 'TXT');
+    const res = await util.resolver.lookup('test-txt', 'TXT');
 
     assert.strictEqual(res.code, wire.codes.NOERROR);
 
@@ -133,7 +133,7 @@ describe('Basic sync & resolve', function() {
   });
 
   it('should resolve GLUE4 without glue', async () => {
-    const res = await util.resolver.resolveRaw('test-glue4', 'NS');
+    const res = await util.resolver.lookup('test-glue4', 'NS');
 
     assert.strictEqual(res.code, wire.codes.NOERROR);
 
@@ -148,7 +148,7 @@ describe('Basic sync & resolve', function() {
   });
 
   it('should resolve GLUE4 with glue', async () => {
-    const res = await util.resolver.resolveRaw('test-glue4-glue', 'NS');
+    const res = await util.resolver.lookup('test-glue4-glue', 'NS');
 
     assert.strictEqual(res.code, wire.codes.NOERROR);
 
@@ -169,7 +169,7 @@ describe('Basic sync & resolve', function() {
   });
 
   it('should resolve GLUE6 without glue', async () => {
-    const res = await util.resolver.resolveRaw('test-glue6', 'NS');
+    const res = await util.resolver.lookup('test-glue6', 'NS');
 
     assert.strictEqual(res.code, wire.codes.NOERROR);
 
@@ -184,7 +184,7 @@ describe('Basic sync & resolve', function() {
   });
 
   it('should resolve GLUE6 with glue', async () => {
-    const res = await util.resolver.resolveRaw('test-glue6-glue', 'NS');
+    const res = await util.resolver.lookup('test-glue6-glue', 'NS');
 
     assert.strictEqual(res.code, wire.codes.NOERROR);
 
@@ -205,7 +205,7 @@ describe('Basic sync & resolve', function() {
   });
 
   it('should resolve SYNTH4 with glue', async () => {
-    const res = await util.resolver.resolveRaw('test-synth4', 'NS');
+    const res = await util.resolver.lookup('test-synth4', 'NS');
 
     assert.strictEqual(res.code, wire.codes.NOERROR);
 
@@ -226,7 +226,7 @@ describe('Basic sync & resolve', function() {
   });
 
   it('should resolve SYNTH6 with glue', async () => {
-    const res = await util.resolver.resolveRaw('test-synth6', 'NS');
+    const res = await util.resolver.lookup('test-synth6', 'NS');
 
     assert.strictEqual(res.code, wire.codes.NOERROR);
 

--- a/integration/test/sync-resolve-test.js
+++ b/integration/test/sync-resolve-test.js
@@ -1,0 +1,248 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+/* eslint max-len: "off" */
+/* eslint no-return-assign: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const wire = require('bns/lib/wire');
+
+const TestUtil = require('../test-util');
+const util = new TestUtil();
+
+describe('Basic sync & resolve', function() {
+  this.timeout(20000);
+
+  before(async () => {
+    await util.open();
+  });
+
+  after(async () => {
+    await util.close();
+  });
+
+  const names = {
+    'test-ds': [{
+      'type': 'DS',
+      'keyTag': 57355,
+      'algorithm': 8,
+      'digestType': 2,
+      'digest': '95a57c3bab7849dbcddf7c72ada71a88146b141110318ca5be672057e865c3e2'
+    }],
+
+    'test-ns': [{
+      'type': 'NS',
+      'ns': 'ns1.hns.'
+    }],
+
+    'test-txt': [{
+      'type': 'TXT',
+      'txt': ['hello world']
+    }],
+
+    'test-glue4':[{
+      'type': 'GLUE4',
+      'ns': 'ns1.outofbailwick.',
+      'address': '10.20.30.40'
+    }],
+
+    'test-glue4-glue':[{
+      'type': 'GLUE4',
+      'ns': 'ns1.test-glue4-glue.',
+      'address': '10.20.30.40'
+    }],
+
+    'test-glue6':[{
+      'type': 'GLUE6',
+      'ns': 'ns1.outofbailwick.',
+      'address': '2600:8805:3e00:1f4a::2000'
+    }],
+
+    'test-glue6-glue':[{
+      'type': 'GLUE6',
+      'ns': 'ns1.test-glue6-glue.',
+      'address': '2600:8805:3e00:1f4a::2000'
+    }],
+
+    'test-synth4':[{
+      'type': 'SYNTH4',
+      'address': '127.0.0.2'
+    }],
+
+    'test-synth6':[{
+      'type': 'SYNTH6',
+      'address': '::2'
+    }]
+  };
+
+  function compareImportantProperties(obj1, obj2, props) {
+    for (const prop of props) {
+      assert(obj1[prop] && obj2[prop]);
+      assert.deepStrictEqual(obj1[prop], obj2[prop]);
+    }
+  }
+
+  it('should register names and sync', async() => {
+    await util.generate(100);
+    await util.registerNames(names);
+    await util.waitForSync();
+  });
+
+  it('should resolve DS', async () => {
+    const res = await util.resolver.resolveRaw('test-ds', 'DS');
+
+    assert.strictEqual(res.code, wire.codes.NOERROR);
+
+    assert(res.answer.length);
+    const answer = res.answer[0];
+    assert.strictEqual(answer.type, wire.types.DS);
+    compareImportantProperties(
+      answer.data.getJSON(),
+      names['test-ds'][0],
+      ['keyTag', 'algorithm', 'digestType', 'digest']
+    );
+  });
+
+  it('should resolve NS', async () => {
+    const res = await util.resolver.resolveRaw('test-ns', 'NS');
+
+    assert.strictEqual(res.code, wire.codes.NOERROR);
+
+    assert(res.authority.length);
+    const referal = res.authority[0];
+    assert.strictEqual(referal.type, wire.types.NS);
+    assert.deepStrictEqual(
+      referal.data.getJSON()['ns'],
+      names['test-ns'][0]['ns']
+    );
+  });
+
+  it('should resolve TXT', async () => {
+    const res = await util.resolver.resolveRaw('test-txt', 'TXT');
+
+    assert.strictEqual(res.code, wire.codes.NOERROR);
+
+    assert(res.answer.length);
+    const answer = res.answer[0];
+    assert.strictEqual(answer.type, wire.types.TXT);
+    assert.deepStrictEqual(
+      answer.data.getJSON()['txt'],
+      names['test-txt'][0]['txt']
+    );
+  });
+
+  it('should resolve GLUE4 without glue', async () => {
+    const res = await util.resolver.resolveRaw('test-glue4', 'NS');
+
+    assert.strictEqual(res.code, wire.codes.NOERROR);
+
+    assert(!res.additional.length);
+    assert(res.authority.length);
+    const referal = res.authority[0];
+    assert.strictEqual(referal.type, wire.types.NS);
+    assert.deepStrictEqual(
+      referal.data.getJSON()['ns'],
+      names['test-glue4'][0]['ns']
+    );
+  });
+
+  it('should resolve GLUE4 with glue', async () => {
+    const res = await util.resolver.resolveRaw('test-glue4-glue', 'NS');
+
+    assert.strictEqual(res.code, wire.codes.NOERROR);
+
+    assert(res.additional.length);
+    assert(res.authority.length);
+    const referal = res.authority[0];
+    assert.strictEqual(referal.type, wire.types.NS);
+    assert.deepStrictEqual(
+      referal.data.getJSON()['ns'],
+      names['test-glue4-glue'][0]['ns']
+    );
+    const additional = res.additional[0];
+    assert.strictEqual(additional.type, wire.types.A);
+    assert.deepStrictEqual(
+      additional.data.getJSON()['address'],
+      names['test-glue4-glue'][0]['address']
+    );
+  });
+
+  it('should resolve GLUE6 without glue', async () => {
+    const res = await util.resolver.resolveRaw('test-glue6', 'NS');
+
+    assert.strictEqual(res.code, wire.codes.NOERROR);
+
+    assert(!res.additional.length);
+    assert(res.authority.length);
+    const referal = res.authority[0];
+    assert.strictEqual(referal.type, wire.types.NS);
+    assert.deepStrictEqual(
+      referal.data.getJSON()['ns'],
+      names['test-glue6'][0]['ns']
+    );
+  });
+
+  it('should resolve GLUE6 with glue', async () => {
+    const res = await util.resolver.resolveRaw('test-glue6-glue', 'NS');
+
+    assert.strictEqual(res.code, wire.codes.NOERROR);
+
+    assert(res.additional.length);
+    assert(res.authority.length);
+    const referal = res.authority[0];
+    assert.strictEqual(referal.type, wire.types.NS);
+    assert.deepStrictEqual(
+      referal.data.getJSON()['ns'],
+      names['test-glue6-glue'][0]['ns']
+    );
+    const additional = res.additional[0];
+    assert.strictEqual(additional.type, wire.types.AAAA);
+    assert.deepStrictEqual(
+      additional.data.getJSON()['address'],
+      names['test-glue6-glue'][0]['address']
+    );
+  });
+
+  it('should resolve SYNTH4 with glue', async () => {
+    const res = await util.resolver.resolveRaw('test-synth4', 'NS');
+
+    assert.strictEqual(res.code, wire.codes.NOERROR);
+
+    assert(res.additional.length);
+    assert(res.authority.length);
+    const referal = res.authority[0];
+    assert.strictEqual(referal.type, wire.types.NS);
+    assert.deepStrictEqual(
+      referal.data.getJSON()['ns'],
+      '_fs0000g._synth.'
+    );
+    const additional = res.additional[0];
+    assert.strictEqual(additional.type, wire.types.A);
+    assert.deepStrictEqual(
+      additional.data.getJSON()['address'],
+      names['test-synth4'][0]['address']
+    );
+  });
+
+  it('should resolve SYNTH6 with glue', async () => {
+    const res = await util.resolver.resolveRaw('test-synth6', 'NS');
+
+    assert.strictEqual(res.code, wire.codes.NOERROR);
+
+    assert(res.additional.length);
+    assert(res.authority.length);
+    const referal = res.authority[0];
+    assert.strictEqual(referal.type, wire.types.NS);
+    assert.deepStrictEqual(
+      referal.data.getJSON()['ns'],
+      '_00000000000000000000000008._synth.'
+    );
+    const additional = res.additional[0];
+    assert.strictEqual(additional.type, wire.types.AAAA);
+    assert.deepStrictEqual(
+      additional.data.getJSON()['address'],
+      names['test-synth6'][0]['address']
+    );
+  });
+});

--- a/src/constants.h
+++ b/src/constants.h
@@ -1,6 +1,7 @@
 #ifndef _HSK_CONSTANTS_H
 #define _HSK_CONSTANTS_H
 
+#include "config.h"
 #include "genesis.h"
 
 #define HSK_MAIN 0
@@ -13,7 +14,7 @@
 #endif
 
 #define HSK_MAX_MESSAGE (8 * 1000 * 1000)
-#define HSK_USER_AGENT "/hnsd:1.0.0/"
+#define HSK_USER_AGENT "/"PACKAGE_NAME":"PACKAGE_VERSION"/"
 #define HSK_PROTO_VERSION 1
 #define HSK_SERVICES 0
 #define HSK_MAX_DATA_SIZE 668

--- a/src/daemon.c
+++ b/src/daemon.c
@@ -12,6 +12,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include "constants.h"
 #include "hsk.h"
 #include "pool.h"
 #include "ns.h"
@@ -109,7 +110,7 @@ static void
 help(int r) {
   fprintf(stderr,
     "\n"
-    "hnsd 1.0.0\n"
+    PACKAGE_NAME" "PACKAGE_VERSION" ("HSK_NETWORK_NAME")\n"
     "  Copyright (c) 2018, Christopher Jeffrey <chjj@handshake.org>\n"
     "\n"
     "Usage: hnsd [options]\n"
@@ -146,6 +147,9 @@ help(int r) {
     "  -a, --user-agent <string>\n"
     "    Add supplemental user agent string in p2p version message.\n"
     "\n"
+    "  -v, --version\n"
+    "    Print version and network build information and exit.\n"
+    "\n"
 #ifndef _WIN32
     "  -d, --daemon\n"
     "    Fork and background the process.\n"
@@ -161,13 +165,14 @@ help(int r) {
 
 static void
 parse_arg(int argc, char **argv, hsk_options_t *opt) {
-  const static char *optstring = "c:n:r:i:u:p:k:s:l:h:a"
+  const static char *optstring = "hvc:n:r:i:u:p:k:s:l:a:"
 #ifndef _WIN32
-    ":d"
+    "d"
 #endif
     ;
 
   const static struct option longopts[] = {
+    { "version", no_argument, NULL, 'v' },
     { "config", required_argument, NULL, 'c' },
     { "ns-host", required_argument, NULL, 'n' },
     { "rs-host", required_argument, NULL, 'r' },
@@ -200,6 +205,11 @@ parse_arg(int argc, char **argv, hsk_options_t *opt) {
       break;
 
     switch (o) {
+      case 'v': {
+        printf("%s (%s)\n", PACKAGE_VERSION, HSK_NETWORK_NAME);
+        exit(0);
+      }
+
       case 'h': {
         return help(0);
       }

--- a/test/base32-test.c
+++ b/test/base32-test.c
@@ -1,0 +1,25 @@
+#include <assert.h>
+
+#include "base32.h"
+
+static void
+test_base32_encode_decode() {
+  const char *str = "5l6tm80";
+  const uint8_t expected[4] = {45, 77, 219, 32};
+
+  uint8_t ip[4];
+  hsk_base32_decode_hex(str, ip, false);
+  for (int i = 0; i < 4; i++) {
+    assert(ip[i] == expected[i]);
+  }
+
+  char encoded[8];
+  hsk_base32_encode_hex(ip, 4, encoded, false);
+  assert(strcmp(encoded, str) == 0);
+}
+
+void
+test_base32() {
+  printf(" test_base32_encode_decode\n");
+  test_base32_encode_decode();
+}

--- a/test/hnsd-test.c
+++ b/test/hnsd-test.c
@@ -1,7 +1,7 @@
-#include <assert.h>
-#include "base32.h"
-#include "resource.h"
-#include "resource.c"
+#include <stdio.h>
+#include <stdint.h>
+
+#include "hnsd-test.h"
 
 void
 print_array(uint8_t *arr, size_t size){
@@ -11,60 +11,15 @@ print_array(uint8_t *arr, size_t size){
   printf("\n");
 }
 
-void
-test_base32() {
-  const char *str = "5l6tm80";
-  const uint8_t expected[4] = {45, 77, 219, 32};
-
-  uint8_t ip[4];
-  hsk_base32_decode_hex(str, ip, false);
-  for (int i = 0; i < 4; i++) {
-    assert(ip[i] == expected[i]);
-  }
-
-  char encoded[8];
-  hsk_base32_encode_hex(ip, 4, encoded, false);
-  assert(strcmp(encoded, str) == 0);
-}
-
-void
-test_pointer_to_ip() {
-  const char *str4 = "_5l6tm80._synth";
-  const uint8_t expected4[4] = {45, 77, 219, 32};
-  uint8_t ip4[4];
-  uint16_t family4;
-
-  bool ret4 = pointer_to_ip(str4, ip4, &family4);
-  assert(ret4);
-  for (int i = 0; i < 4; i++) {
-    assert(ip4[i] == expected4[i]);
-  }
-  assert(family4 == HSK_DNS_A);
-
-  const char *str6 = "_400hjs000l2gol000fvvsc9cpg._synth";
-  const uint8_t expected6[16] = {
-    0x20, 0x01, 0x19, 0xf0,
-    0x00, 0x05, 0x45, 0x0c,
-    0x54, 0x00, 0x03, 0xff,
-    0xfe, 0x31, 0x2c, 0xcc
-  };
-
-  uint8_t ip6[16];
-  uint16_t family6;
-
-  bool ret6 = pointer_to_ip(str6, ip6, &family6);
-  assert(ret6);
-  for (int i = 0; i < 16; i++) {
-    assert(ip6[i] == expected6[i]);
-  }
-  assert(family6 == HSK_DNS_AAAA);
-}
-
 int
 main() {
   printf("Testing hnsd...\n");
+
+  printf("test_base32\n");
   test_base32();
-  test_pointer_to_ip();
+
+  printf("test_resource\n");
+  test_resource();
 
   printf("ok\n");
 

--- a/test/hnsd-test.h
+++ b/test/hnsd-test.h
@@ -1,0 +1,10 @@
+#ifndef _HSK_HNSD_TEST_H
+#define _HSK_HNSD_TEST_H
+
+void
+test_base32();
+
+void
+test_resource();
+
+#endif

--- a/test/resource-test.c
+++ b/test/resource-test.c
@@ -1,0 +1,42 @@
+#include <assert.h>
+
+#include "resource.h"
+
+static void
+test_resource_pointer_to_ip() {
+  const char *str4 = "_5l6tm80._synth";
+  const uint8_t expected4[4] = {45, 77, 219, 32};
+  uint8_t ip4[4];
+  uint16_t family4;
+
+  bool ret4 = pointer_to_ip(str4, ip4, &family4);
+  assert(ret4);
+  for (int i = 0; i < 4; i++) {
+    assert(ip4[i] == expected4[i]);
+  }
+  assert(family4 == HSK_DNS_A);
+
+  const char *str6 = "_400hjs000l2gol000fvvsc9cpg._synth";
+  const uint8_t expected6[16] = {
+    0x20, 0x01, 0x19, 0xf0,
+    0x00, 0x05, 0x45, 0x0c,
+    0x54, 0x00, 0x03, 0xff,
+    0xfe, 0x31, 0x2c, 0xcc
+  };
+
+  uint8_t ip6[16];
+  uint16_t family6;
+
+  bool ret6 = pointer_to_ip(str6, ip6, &family6);
+  assert(ret6);
+  for (int i = 0; i < 16; i++) {
+    assert(ip6[i] == expected6[i]);
+  }
+  assert(family6 == HSK_DNS_AAAA);
+}
+
+void
+test_resource() {
+  printf(" test_resource_pointer_to_ip\n");
+  test_resource_pointer_to_ip();
+}


### PR DESCRIPTION
Closes #23 

This cleans up the framework for unit tests (written C and compiled into executable `test_hnsd`) and also introduces a new integration test system using nodejs and hsd.

```

--> ./test_hnsd
Testing hnsd...
test_base32
 test_base32_encode_decode
test_resource
 test_resource_pointer_to_ip
ok
--> cd integration/
--> npm run test

> hnsd_integration_test@1.0.0 test
> bmocha --reporter spec test/*.js


  Basic sync & resolve
    ✓ should register names and sync (845ms)
    ✓ should resolve DS
    ✓ should resolve NS
    ✓ should resolve TXT
    ✓ should resolve GLUE4 without glue
    ✓ should resolve GLUE4 with glue
    ✓ should resolve GLUE6 without glue
    ✓ should resolve GLUE6 with glue
    ✓ should resolve SYNTH4 with glue
    ✓ should resolve SYNTH6 with glue

  10 passing (953ms)

```