### PR TITLE
Introduce Hesiod (class HS) metadata resolver

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -80,6 +80,7 @@ noinst_PROGRAMS = test_hnsd
 
 test_hnsd_SOURCES = test/hnsd-test.c     \
                     test/base32-test.c   \
+                    test/dns-test.c      \
                     test/resource-test.c
 
 test_hnsd_LDFLAGS = -static

--- a/Makefile.am
+++ b/Makefile.am
@@ -40,6 +40,7 @@ libhsk_la_SOURCES = src/addr.c                   \
                     src/error.c                  \
                     src/hash.c                   \
                     src/header.c                 \
+                    src/hesiod.c                 \
                     src/map.c                    \
                     src/msg.c                    \
                     src/poly1305/poly1305.c      \

--- a/docs/hesiod.md
+++ b/docs/hesiod.md
@@ -1,0 +1,112 @@
+# hnsd Hesiod API
+
+hnsd does not have an http server, but we can use special DNS requests to query
+the node for metadata about the blockchain and network. These queries are made
+using the Hesiod (`HS`) class, as opposed to the usual Internet (`IN`) class.
+[Hesiod service](https://en.wikipedia.org/wiki/Hesiod_(name_service)) was
+developed in the 1980s and many legacy DNS tools like `dig` support it.
+The abbreviation "HS" is a nice coincidence for Handshake.
+
+Hesiod is only supported by the hnsd root name server, and currently only
+responds to requests from local connections. Queries are made by requesting TXT
+records of class HS using a domain name tree that represents a hierarchical
+data structure (like a JSON object).
+
+## Implied wildcard (`*.domain`)
+
+All HS requests are preceded by an implied wildcard. This means that if a
+requested name has any subdomains, they will all be returned, recursively.
+Because of this a request for `HS TXT .` will return ALL available data
+from the API.
+
+## Ports
+
+Reminder the root nameserver ports for each HNS network:
+
+| Network |  Port  |
+|---------|--------|
+| main    | `5349` |
+| testnet | `15349`|
+| regtest | `25349`|
+| simnet  | `35349`|
+
+## Quick Examples
+
+Get the current block height (mainnet):
+
+```
+$ dig @127.0.0.1 -p 5349 HS TXT height.tip.chain.hnsd +short
+"70000"
+```
+
+Get the number of peers (mainnet):
+
+```
+$ dig @127.0.0.1 -p 5349 HS TXT size.pool.hnsd +short
+"8"
+```
+
+## Big examples
+
+Get all chain tip data (mainnet):
+
+```
+$ dig @127.0.0.1 -p 5349 HS TXT tip.chain.hnsd
+
+...
+
+;; ANSWER SECTION:
+hash.tip.chain.hnsd.    0       HS      TXT     "0000000000000007cde5b551d04468b421d05a7ce862e7e50cff3c397af315ea"
+height.tip.chain.hnsd.  0       HS      TXT     "145921"
+time.tip.chain.hnsd.    0       HS      TXT     "1668181113"
+
+...
+```
+
+Get information about connected peers (mainnet):
+
+```
+$ dig @127.0.0.1 -p 5349 HS TXT peers.pool.hnsd
+
+...
+
+;; ANSWER SECTION:
+host.0.peers.pool.hnsd. 0       HS      TXT     "159.69.46.23:44806"
+agent.0.peers.pool.hnsd. 0      HS      TXT     "/hsd:4.0.0/"
+headers.0.peers.pool.hnsd. 0    HS      TXT     "20000"
+proofs.0.peers.pool.hnsd. 0     HS      TXT     "0"
+state.0.peers.pool.hnsd. 0      HS      TXT     "HSK_STATE_HANDSHAKE"
+
+...
+```
+
+## Complete HS API object
+
+```
+.: {
+  hnsd: {
+    chain: {
+      tip: {
+        hash:   `32 byte hex string`,
+        height: `unsigned int`,
+        time:   `unsigned int`
+      },
+      synced:   `boolean`,
+      progress: `float`
+    },
+    pool: {
+      size:     `unsigned int`,
+      [index].peers: [
+        {
+          host:  `string`,
+          agent: `string`,
+          headers `unsigned int`,
+          proofs: `unsigned int`,
+          state: `string`
+        }
+      ]
+    }
+  }
+}
+```
+

--- a/docs/hesiod.md
+++ b/docs/hesiod.md
@@ -98,11 +98,11 @@ state.0.peers.pool.hnsd. 0      HS      TXT     "HSK_STATE_HANDSHAKE"
       size:     `unsigned int`,
       [index].peers: [
         {
-          host:  `string`,
-          agent: `string`,
-          headers `unsigned int`,
-          proofs: `unsigned int`,
-          state: `string`
+          host:    `string`,
+          agent:   `string`,
+          headers: `unsigned int`, // number of headers received from peer
+          proofs:  `unsigned int`, // number of urkel proofs received from peer
+          state:   `string`        // connection status, see pool.h
         }
       ]
     }

--- a/integration/test-util.js
+++ b/integration/test-util.js
@@ -114,6 +114,18 @@ class TestUtil {
     return answer[0].data.txt[0];
   }
 
+  async waitForHS(name, value) {
+    const answer = await this.resolveHS(name);
+    if (answer === String(value))
+      return value;
+
+    return new Promise(async (resolve) => {
+      setTimeout(async () => {
+        resolve(this.waitForHS(name));
+      }, 100);
+    });
+  }
+
   async getHeights() {
     const hnsd = this.hnsd
                  ? await this.resolveHS('height.tip.chain.hnsd.')

--- a/integration/test-util.js
+++ b/integration/test-util.js
@@ -14,11 +14,16 @@ const hnsdPath = path.join(__dirname, '..', 'hnsd');
 
 class TestUtil {
   constructor() {
+    this.host = '127.0.0.1';
+    this.port = 10000;
+
     this.node = new FullNode({
       memory: true,
       network,
       listen: true,
-      port: 10000,
+      host: this.host,
+      port: this.port,
+      brontidePort: 46888, // avoid hnsd connecting via brontide
       noDns: true,
       plugins: [require('hsd/lib/wallet/plugin')]
     });
@@ -53,7 +58,7 @@ class TestUtil {
     return new Promise((resolve, reject) => {
       this.hnsd = spawn(
         path.join(__dirname, '..', 'hnsd'),
-        ['-s', '127.0.0.1:10000'],
+        ['-s', `${this.host}:${this.port}`],
         {stdio: 'ignore'}
       );
 

--- a/integration/test-util.js
+++ b/integration/test-util.js
@@ -5,6 +5,7 @@ const {spawn, execSync} = require('child_process');
 const assert = require('bsert');
 const path = require('path');
 const {FullNode} = require('hsd');
+const wire = require('bns/lib/wire');
 const StubResolver = require('bns/lib/resolver/stub');
 const {EOL} = require('os');
 const {version} = require('./package.json');
@@ -39,29 +40,25 @@ class TestUtil {
       'Network or version mismatch'
     );
 
+    await this.resolver.open();
     await this.node.open();
     await this.node.connect();
 
     this.wallet = this.node.plugins.walletdb;
 
-    this.hnsd = spawn(
-      hnsdPath,
-      ['-s', '127.0.0.1:10000']
-    );
+    return this.openHNSD();
+  }
 
-    this.hnsd.stdout.on('data', (data) => {
-      // TODO: `data` is always 8192 bytes and output gets cut off, why?
-      const chunk = data.toString('ascii');
-      const lines = chunk.split(/\n/);
+  async openHNSD() {
+    return new Promise((resolve, reject) => {
+      this.hnsd = spawn(
+        path.join(__dirname, '..', 'hnsd'),
+        ['-s', '127.0.0.1:10000'],
+        {stdio: 'ignore'}
+      );
 
-      for (const line of lines) {
-        const words = line.split(/\s+/);
-
-        if (words[0] !== 'chain' || words.length < 2)
-          continue;
-
-        this.hnsdHeight = parseInt(words[1].slice(1, -2));
-      }
+      this.hnsd.on('spawn', () => resolve());
+      this.hnsd.on('error', () => reject());
     });
   }
 
@@ -100,21 +97,38 @@ class TestUtil {
     await this.generate(12); // safe root
   }
 
-  waitForSync() {
-    return new Promise((resolve, reject) => {
-      // Hack
-      setTimeout(() => {
-        resolve();
-      }, 5000);
+  async resolveHS(name) {
+    const qs = wire.Question.fromJSON({
+      name,
+      class: 'HS',
+      type: 'TXT'
+    });
 
-    // // TODO: Fix hnsd stdout parsing for chain height
-    //   setTimeout(() => {
-    //     reject(new Error('Timeout waiting for sync'));
-    //   }, 5000);
-    //   setInterval(() => {
-    //     if (this.hnsdHeight === this.node.chain.height)
-    //       resolve();
-    //   }, 100);
+    const {answer} = await this.resolver.resolve(qs);
+    assert(answer && answer.length);
+    return answer[0].data.txt[0];
+  }
+
+  async getHeights() {
+    const hnsd = this.hnsd
+                 ? await this.resolveHS('height.tip.chain.hnsd.')
+                 : 0;
+
+    return {
+      hnsd: parseInt(hnsd),
+      hsd: this.node.chain.height
+    };
+  }
+
+  async waitForSync() {
+    const {hsd, hnsd} = await this.getHeights();
+    if (hsd === hnsd)
+      return hnsd;
+
+    return new Promise(async (resolve) => {
+      setTimeout(async () => {
+        resolve(this.waitForSync());
+      }, 100);
     });
   }
 }

--- a/integration/test/hesiod-test.js
+++ b/integration/test/hesiod-test.js
@@ -22,9 +22,35 @@ describe('Hesiod', function() {
     await util.close();
   });
 
+  it('should not be synced', async () => {
+    const qs = wire.Question.fromJSON({
+      name: 'synced.tip.chain.hnsd.',
+      class: 'HS',
+      type: 'TXT'
+    });
+
+    const {answer} = await util.resolver.resolve(qs);
+    assert.strictEqual(answer.length, 1);
+
+    assert.strictEqual(answer[0].data.txt[0], 'false');
+  });
+
   it('should sync', async () => {
     await util.generate(3000); // ensures at least 2x 2000-headers packets
     await util.waitForSync();
+  });
+
+  it('should be synced', async () => {
+    const qs = wire.Question.fromJSON({
+      name: 'synced.tip.chain.hnsd.',
+      class: 'HS',
+      type: 'TXT'
+    });
+
+    const {answer} = await util.resolver.resolve(qs);
+    assert.strictEqual(answer.length, 1);
+
+    assert.strictEqual(answer[0].data.txt[0], 'true');
   });
 
   it('should get chain tip hash', async () => {
@@ -83,9 +109,9 @@ describe('Hesiod', function() {
     });
 
     const {answer} = await util.resolver.resolve(qs);
-    assert.strictEqual(answer.length, 3);
+    assert.strictEqual(answer.length, 4);
 
-    const [hashTxt, heightTxt, timeTxt] = answer;
+    const [hashTxt, heightTxt, timeTxt, syncedTxt] = answer;
 
     assert.strictEqual(hashTxt.name, 'hash.tip.chain.hnsd.');
     assert.strictEqual(hashTxt.data.txt[0], util.node.chain.tip.hash.toString('hex'));
@@ -96,5 +122,8 @@ describe('Hesiod', function() {
 
     assert.strictEqual(timeTxt.name, 'time.tip.chain.hnsd.');
     assert.strictEqual(timeTxt.data.txt[0], String(util.node.chain.tip.time));
+
+    assert.strictEqual(syncedTxt.name, 'synced.tip.chain.hnsd.');
+    assert.strictEqual(syncedTxt.data.txt[0], 'true');
   });
 });

--- a/integration/test/hesiod-test.js
+++ b/integration/test/hesiod-test.js
@@ -26,7 +26,7 @@ describe('Hesiod', function() {
   describe('Chain', function () {
     it('should not be synced', async () => {
       const qs = wire.Question.fromJSON({
-        name: 'synced.tip.chain.hnsd.',
+        name: 'synced.chain.hnsd.',
         class: 'HS',
         type: 'TXT'
       });
@@ -44,7 +44,7 @@ describe('Hesiod', function() {
 
     it('should be synced', async () => {
       const qs = wire.Question.fromJSON({
-        name: 'synced.tip.chain.hnsd.',
+        name: 'synced.chain.hnsd.',
         class: 'HS',
         type: 'TXT'
       });
@@ -123,7 +123,7 @@ describe('Hesiod', function() {
       assert.strictEqual(answer[2].name, 'time.tip.chain.hnsd.');
       assert.strictEqual(answer[2].data.txt[0], String(util.node.chain.tip.time));
 
-      assert.strictEqual(answer[3].name, 'synced.tip.chain.hnsd.');
+      assert.strictEqual(answer[3].name, 'synced.chain.hnsd.');
       assert.strictEqual(answer[3].data.txt[0], 'true');
 
       assert.strictEqual(answer[4].name, 'progress.chain.hnsd.');

--- a/integration/test/hesiod-test.js
+++ b/integration/test/hesiod-test.js
@@ -135,6 +135,7 @@ describe('Hesiod', function() {
     it('should have no peers', async () => {
       // Disconnect
       await util.node.pool.close();
+      await util.waitForHS('size.pool.hnsd.', 0);
 
       const qs = wire.Question.fromJSON({
         name: 'pool.hnsd.',

--- a/integration/test/hesiod-test.js
+++ b/integration/test/hesiod-test.js
@@ -12,7 +12,7 @@ const TestUtil = require('../test-util');
 const util = new TestUtil();
 
 describe('Hesiod', function() {
-  this.timeout(20000);
+  this.timeout(30000);
 
   before(async () => {
     await util.open();
@@ -23,7 +23,7 @@ describe('Hesiod', function() {
   });
 
   it('should sync', async () => {
-    await util.generate(123);
+    await util.generate(3000); // ensures at least 2x 2000-headers packets
     await util.waitForSync();
   });
 
@@ -52,7 +52,7 @@ describe('Hesiod', function() {
     assert.strictEqual(answer.length, 1);
 
     const height = answer[0].data.txt[0];
-    assert.strictEqual(height, '123');
+    assert.strictEqual(height, '3000');
     assert.strictEqual(height, String(util.node.chain.tip.height));
   });
 
@@ -70,6 +70,11 @@ describe('Hesiod', function() {
     assert.strictEqual(time, String(util.node.chain.tip.time));
   });
 
+  it('generate more blocks', async () => {
+    await util.generate(3000); // ensures at least 2x 2000-headers packets
+    await util.waitForSync();
+  });
+
   it('should get all chain info', async () => {
     const qs = wire.Question.fromJSON({
       name: 'chain.hnsd.',
@@ -79,5 +84,17 @@ describe('Hesiod', function() {
 
     const {answer} = await util.resolver.resolve(qs);
     assert.strictEqual(answer.length, 3);
+
+    const [hashTxt, heightTxt, timeTxt] = answer;
+
+    assert.strictEqual(hashTxt.name, 'hash.tip.chain.hnsd.');
+    assert.strictEqual(hashTxt.data.txt[0], util.node.chain.tip.hash.toString('hex'));
+
+    assert.strictEqual(heightTxt.name, 'height.tip.chain.hnsd.');
+    assert.strictEqual(heightTxt.data.txt[0], String(util.node.chain.tip.height));
+    assert.strictEqual(heightTxt.data.txt[0], '6000');
+
+    assert.strictEqual(timeTxt.name, 'time.tip.chain.hnsd.');
+    assert.strictEqual(timeTxt.data.txt[0], String(util.node.chain.tip.time));
   });
 });

--- a/integration/test/hesiod-test.js
+++ b/integration/test/hesiod-test.js
@@ -11,7 +11,7 @@ const wire = require('bns/lib/wire');
 const TestUtil = require('../test-util');
 const util = new TestUtil();
 
-describe('Basic sync & resolve', function() {
+describe('Hesiod', function() {
   this.timeout(20000);
 
   before(async () => {
@@ -27,21 +27,57 @@ describe('Basic sync & resolve', function() {
     await util.waitForSync();
   });
 
-  it('should get chain info', async () => {
+  it('should get chain tip hash', async () => {
     const qs = wire.Question.fromJSON({
-      name: 'info.chain.hnsd.',
+      name: 'hash.tip.chain.hnsd.',
       class: 'HS',
       type: 'TXT'
     });
 
     const {answer} = await util.resolver.resolve(qs);
-    assert.strictEqual(answer.length, 2);
+    assert.strictEqual(answer.length, 1);
+
+    const hash = answer[0].data.txt[0];
+    assert.strictEqual(hash, util.node.chain.tip.hash.toString('hex'));
+  });
+
+  it('should get chain tip height', async () => {
+    const qs = wire.Question.fromJSON({
+      name: 'height.tip.chain.hnsd.',
+      class: 'HS',
+      type: 'TXT'
+    });
+
+    const {answer} = await util.resolver.resolve(qs);
+    assert.strictEqual(answer.length, 1);
 
     const height = answer[0].data.txt[0];
-    const hash = answer[1].data.txt[0];
-
     assert.strictEqual(height, '123');
-    assert.strictEqual(height, String(util.node.chain.height));
-    assert.strictEqual(hash, util.node.chain.tip.hash.toString('hex'));
+    assert.strictEqual(height, String(util.node.chain.tip.height));
+  });
+
+  it('should get chain tip time', async () => {
+    const qs = wire.Question.fromJSON({
+      name: 'time.tip.chain.hnsd.',
+      class: 'HS',
+      type: 'TXT'
+    });
+
+    const {answer} = await util.resolver.resolve(qs);
+    assert.strictEqual(answer.length, 1);
+
+    const time = answer[0].data.txt[0];
+    assert.strictEqual(time, String(util.node.chain.tip.time));
+  });
+
+  it('should get all chain info', async () => {
+    const qs = wire.Question.fromJSON({
+      name: 'chain.hnsd.',
+      class: 'HS',
+      type: 'TXT'
+    });
+
+    const {answer} = await util.resolver.resolve(qs);
+    assert.strictEqual(answer.length, 3);
   });
 });

--- a/integration/test/hesiod-test.js
+++ b/integration/test/hesiod-test.js
@@ -1,0 +1,47 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+/* eslint max-len: "off" */
+/* eslint no-return-assign: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const wire = require('bns/lib/wire');
+
+const TestUtil = require('../test-util');
+const util = new TestUtil();
+
+describe('Basic sync & resolve', function() {
+  this.timeout(20000);
+
+  before(async () => {
+    await util.open();
+  });
+
+  after(async () => {
+    await util.close();
+  });
+
+  it('should sync', async () => {
+    await util.generate(123);
+    await util.waitForSync();
+  });
+
+  it('should get chain info', async () => {
+    const qs = wire.Question.fromJSON({
+      name: 'info.chain.hnsd.',
+      class: 'HS',
+      type: 'TXT'
+    });
+
+    const {answer} = await util.resolver.resolve(qs);
+    assert.strictEqual(answer.length, 2);
+
+    const height = answer[0].data.txt[0];
+    const hash = answer[1].data.txt[0];
+
+    assert.strictEqual(height, '123');
+    assert.strictEqual(height, String(util.node.chain.height));
+    assert.strictEqual(hash, util.node.chain.tip.hash.toString('hex'));
+  });
+});

--- a/integration/test/hesiod-test.js
+++ b/integration/test/hesiod-test.js
@@ -7,6 +7,7 @@
 
 const assert = require('bsert');
 const wire = require('bns/lib/wire');
+const {pkg} = require('hsd');
 
 const TestUtil = require('../test-util');
 const util = new TestUtil();
@@ -22,108 +23,157 @@ describe('Hesiod', function() {
     await util.close();
   });
 
-  it('should not be synced', async () => {
-    const qs = wire.Question.fromJSON({
-      name: 'synced.tip.chain.hnsd.',
-      class: 'HS',
-      type: 'TXT'
+  describe('Chain', function () {
+    it('should not be synced', async () => {
+      const qs = wire.Question.fromJSON({
+        name: 'synced.tip.chain.hnsd.',
+        class: 'HS',
+        type: 'TXT'
+      });
+
+      const {answer} = await util.resolver.resolve(qs);
+      assert.strictEqual(answer.length, 1);
+
+      assert.strictEqual(answer[0].data.txt[0], 'false');
     });
 
-    const {answer} = await util.resolver.resolve(qs);
-    assert.strictEqual(answer.length, 1);
-
-    assert.strictEqual(answer[0].data.txt[0], 'false');
-  });
-
-  it('should sync', async () => {
-    await util.generate(3000); // ensures at least 2x 2000-headers packets
-    await util.waitForSync();
-  });
-
-  it('should be synced', async () => {
-    const qs = wire.Question.fromJSON({
-      name: 'synced.tip.chain.hnsd.',
-      class: 'HS',
-      type: 'TXT'
+    it('should sync', async () => {
+      await util.generate(3000); // ensures at least 2x 2000-headers packets
+      await util.waitForSync();
     });
 
-    const {answer} = await util.resolver.resolve(qs);
-    assert.strictEqual(answer.length, 1);
+    it('should be synced', async () => {
+      const qs = wire.Question.fromJSON({
+        name: 'synced.tip.chain.hnsd.',
+        class: 'HS',
+        type: 'TXT'
+      });
 
-    assert.strictEqual(answer[0].data.txt[0], 'true');
-  });
+      const {answer} = await util.resolver.resolve(qs);
+      assert.strictEqual(answer.length, 1);
 
-  it('should get chain tip hash', async () => {
-    const qs = wire.Question.fromJSON({
-      name: 'hash.tip.chain.hnsd.',
-      class: 'HS',
-      type: 'TXT'
+      assert.strictEqual(answer[0].data.txt[0], 'true');
     });
 
-    const {answer} = await util.resolver.resolve(qs);
-    assert.strictEqual(answer.length, 1);
+    it('should get chain tip hash', async () => {
+      const qs = wire.Question.fromJSON({
+        name: 'hash.tip.chain.hnsd.',
+        class: 'HS',
+        type: 'TXT'
+      });
 
-    const hash = answer[0].data.txt[0];
-    assert.strictEqual(hash, util.node.chain.tip.hash.toString('hex'));
-  });
+      const {answer} = await util.resolver.resolve(qs);
+      assert.strictEqual(answer.length, 1);
 
-  it('should get chain tip height', async () => {
-    const qs = wire.Question.fromJSON({
-      name: 'height.tip.chain.hnsd.',
-      class: 'HS',
-      type: 'TXT'
+      const hash = answer[0].data.txt[0];
+      assert.strictEqual(hash, util.node.chain.tip.hash.toString('hex'));
     });
 
-    const {answer} = await util.resolver.resolve(qs);
-    assert.strictEqual(answer.length, 1);
+    it('should get chain tip height', async () => {
+      const qs = wire.Question.fromJSON({
+        name: 'height.tip.chain.hnsd.',
+        class: 'HS',
+        type: 'TXT'
+      });
 
-    const height = answer[0].data.txt[0];
-    assert.strictEqual(height, '3000');
-    assert.strictEqual(height, String(util.node.chain.tip.height));
-  });
+      const {answer} = await util.resolver.resolve(qs);
+      assert.strictEqual(answer.length, 1);
 
-  it('should get chain tip time', async () => {
-    const qs = wire.Question.fromJSON({
-      name: 'time.tip.chain.hnsd.',
-      class: 'HS',
-      type: 'TXT'
+      const height = answer[0].data.txt[0];
+      assert.strictEqual(height, '3000');
+      assert.strictEqual(height, String(util.node.chain.tip.height));
     });
 
-    const {answer} = await util.resolver.resolve(qs);
-    assert.strictEqual(answer.length, 1);
+    it('should get chain tip time', async () => {
+      const qs = wire.Question.fromJSON({
+        name: 'time.tip.chain.hnsd.',
+        class: 'HS',
+        type: 'TXT'
+      });
 
-    const time = answer[0].data.txt[0];
-    assert.strictEqual(time, String(util.node.chain.tip.time));
-  });
+      const {answer} = await util.resolver.resolve(qs);
+      assert.strictEqual(answer.length, 1);
 
-  it('generate more blocks', async () => {
-    await util.generate(3000); // ensures at least 2x 2000-headers packets
-    await util.waitForSync();
-  });
-
-  it('should get all chain info', async () => {
-    const qs = wire.Question.fromJSON({
-      name: 'chain.hnsd.',
-      class: 'HS',
-      type: 'TXT'
+      const time = answer[0].data.txt[0];
+      assert.strictEqual(time, String(util.node.chain.tip.time));
     });
 
-    const {answer} = await util.resolver.resolve(qs);
-    assert.strictEqual(answer.length, 4);
+    it('generate more blocks', async () => {
+      await util.generate(3000); // ensures at least 2x 2000-headers packets
+      await util.waitForSync();
+    });
 
-    const [hashTxt, heightTxt, timeTxt, syncedTxt] = answer;
+    it('should get all chain info', async () => {
+      const qs = wire.Question.fromJSON({
+        name: 'chain.hnsd.',
+        class: 'HS',
+        type: 'TXT'
+      });
 
-    assert.strictEqual(hashTxt.name, 'hash.tip.chain.hnsd.');
-    assert.strictEqual(hashTxt.data.txt[0], util.node.chain.tip.hash.toString('hex'));
+      const {answer} = await util.resolver.resolve(qs);
+      assert.strictEqual(answer.length, 5);
 
-    assert.strictEqual(heightTxt.name, 'height.tip.chain.hnsd.');
-    assert.strictEqual(heightTxt.data.txt[0], String(util.node.chain.tip.height));
-    assert.strictEqual(heightTxt.data.txt[0], '6000');
+      assert.strictEqual(answer[0].name, 'hash.tip.chain.hnsd.');
+      assert.strictEqual(answer[0].data.txt[0], util.node.chain.tip.hash.toString('hex'));
 
-    assert.strictEqual(timeTxt.name, 'time.tip.chain.hnsd.');
-    assert.strictEqual(timeTxt.data.txt[0], String(util.node.chain.tip.time));
+      assert.strictEqual(answer[1].name, 'height.tip.chain.hnsd.');
+      assert.strictEqual(answer[1].data.txt[0], String(util.node.chain.tip.height));
+      assert.strictEqual(answer[1].data.txt[0], '6000');
 
-    assert.strictEqual(syncedTxt.name, 'synced.tip.chain.hnsd.');
-    assert.strictEqual(syncedTxt.data.txt[0], 'true');
+      assert.strictEqual(answer[2].name, 'time.tip.chain.hnsd.');
+      assert.strictEqual(answer[2].data.txt[0], String(util.node.chain.tip.time));
+
+      assert.strictEqual(answer[3].name, 'synced.tip.chain.hnsd.');
+      assert.strictEqual(answer[3].data.txt[0], 'true');
+
+      assert.strictEqual(answer[4].name, 'progress.chain.hnsd.');
+      assert.strictEqual(answer[4].data.txt[0], '1.000000');
+    });
+  });
+
+  describe('Pool', function () {
+    it('should have no peers', async () => {
+      // Disconnect
+      await util.node.pool.close();
+
+      const qs = wire.Question.fromJSON({
+        name: 'pool.hnsd.',
+        class: 'HS',
+        type: 'TXT'
+      });
+
+      const {answer} = await util.resolver.resolve(qs);
+      assert.strictEqual(answer.length, 1);
+
+      assert.strictEqual(answer[0].name, 'size.pool.hnsd.');
+      assert.strictEqual(answer[0].data.txt[0], '0');
+    });
+
+    it('should have peer info', async () => {
+      // Reconnect
+      await util.node.pool.open();
+      await util.node.pool.connect();
+      await util.generate(1);
+      await util.waitForSync();
+
+      const qs = wire.Question.fromJSON({
+        name: 'pool.hnsd.',
+        class: 'HS',
+        type: 'TXT'
+      });
+
+      const {answer} = await util.resolver.resolve(qs);
+      assert.strictEqual(answer.length, 3);
+
+      assert.strictEqual(answer[0].name, 'size.pool.hnsd.');
+      assert.strictEqual(answer[0].data.txt[0], '1');
+
+      // Peer id isn't deterministic
+      assert(answer[1].name.match(/host\.[0-65535]\.peers\.pool\.hnsd\./));
+      assert.strictEqual(answer[1].data.txt[0], `${util.host}:${util.port}`);
+
+      assert(answer[2].name.match(/agent\.[0-65535]\.peers\.pool\.hnsd\./));
+      assert.strictEqual(answer[2].data.txt[0], `/${pkg.name}:${pkg.version}/`);
+    });
   });
 });

--- a/src/chain.c
+++ b/src/chain.c
@@ -277,6 +277,19 @@ hsk_chain_maybe_sync(hsk_chain_t *chain) {
   chain->synced = true;
 }
 
+float
+hsk_chain_progress(const hsk_chain_t *chain) {
+  uint64_t start = chain->genesis->time;
+  uint64_t current = chain->tip->time - start;
+  uint64_t end = hsk_timedata_now(chain->td) - start - (40 * 60);
+  float progress = (float)current / end;
+
+  if (progress > 1)
+    return 1;
+
+  return progress;
+}
+
 bool
 hsk_chain_synced(const hsk_chain_t *chain) {
   return chain->synced;

--- a/src/chain.c
+++ b/src/chain.c
@@ -262,12 +262,6 @@ hsk_chain_maybe_sync(hsk_chain_t *chain) {
 
   int64_t now = hsk_timedata_now(chain->td);
 
-  if (now < HSK_LAUNCH_DATE) {
-    hsk_chain_log(chain, "chain is fully synced\n");
-    chain->synced = true;
-    return;
-  }
-
   if (HSK_USE_CHECKPOINTS) {
     if (chain->height < HSK_LAST_CHECKPOINT)
       return;

--- a/src/chain.h
+++ b/src/chain.h
@@ -66,6 +66,9 @@ hsk_chain_get_ancestor(
   uint32_t height
 );
 
+float
+hsk_chain_progress(const hsk_chain_t *chain);
+
 bool
 hsk_chain_synced(const hsk_chain_t *chain);
 

--- a/src/constants.h
+++ b/src/constants.h
@@ -82,7 +82,6 @@ static const uint8_t HSK_CHAINWORK[32] = {
 #define HSK_USE_CHECKPOINTS true
 #define HSK_LAST_CHECKPOINT 1008          // Used for maybe_sync, no block hash
 #define HSK_MAX_TIP_AGE (24 * 60 * 60)
-#define HSK_LAUNCH_DATE 0xffffffff        // Used for maybe_sync, not useful
 
 #elif HSK_NETWORK == HSK_TESTNET
 
@@ -137,7 +136,6 @@ static const uint8_t HSK_CHAINWORK[32] = {
 #define HSK_USE_CHECKPOINTS false
 #define HSK_LAST_CHECKPOINT 0
 #define HSK_MAX_TIP_AGE (2 * 7 * 24 * 60 * 60)
-#define HSK_LAUNCH_DATE 0xffffffff
 
 #elif HSK_NETWORK == HSK_REGTEST
 
@@ -181,7 +179,6 @@ static const uint8_t HSK_CHAINWORK[32] = {
 #define HSK_USE_CHECKPOINTS false
 #define HSK_LAST_CHECKPOINT 0
 #define HSK_MAX_TIP_AGE (2 * 7 * 24 * 60 * 60)
-#define HSK_LAUNCH_DATE 0xffffffff
 
 #elif HSK_NETWORK == HSK_SIMNET
 
@@ -225,7 +222,6 @@ static const uint8_t HSK_CHAINWORK[32] = {
 #define HSK_USE_CHECKPOINTS false
 #define HSK_LAST_CHECKPOINT 0
 #define HSK_MAX_TIP_AGE (2 * 7 * 24 * 60 * 60)
-#define HSK_LAUNCH_DATE 0xffffffff
 
 #else
 

--- a/src/dns.c
+++ b/src/dns.c
@@ -3355,7 +3355,11 @@ hsk_dns_is_subdomain(const char *parent, const char *child) {
   int parent_count = hsk_dns_label_count(parent);
   int child_count = hsk_dns_label_count(child);
 
-  if (parent_count >= child_count)
+  // All domains are children of "."
+  if (parent_count == 0)
+    return true;
+
+  if (parent_count > child_count)
     return false;
 
   uint8_t child_labels[child_count];

--- a/src/hesiod.c
+++ b/src/hesiod.c
@@ -105,8 +105,8 @@ hsk_hesiod_resolve(hsk_dns_req_t *req, hsk_ns_t *ns) {
       goto fail;
   }
 
-  if (hsk_dns_is_subdomain(req->name, "synced.tip.chain.hnsd.")) {
-    if (!hsk_hesiod_txt_push("synced.tip.chain.hnsd.",
+  if (hsk_dns_is_subdomain(req->name, "synced.chain.hnsd.")) {
+    if (!hsk_hesiod_txt_push("synced.chain.hnsd.",
                              ns->pool->chain.synced ? "true" : "false",
                              an))
       goto fail;

--- a/src/hesiod.c
+++ b/src/hesiod.c
@@ -1,0 +1,109 @@
+#include <assert.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "chain.h"
+#include "dns.h"
+#include "ns.h"
+#include "pool.h"
+#include "req.h"
+
+static bool
+hsk_hesiod_txt_push(char *name, char *text, hsk_dns_rrs_t *an) {
+  hsk_dns_rr_t *rr = hsk_dns_rr_create(HSK_DNS_TXT);
+
+  if (!rr)
+    return false;
+
+  rr->ttl = 0;
+  hsk_dns_rr_set_name(rr, name);
+  hsk_dns_txt_rd_t *rd = rr->rd;
+  hsk_dns_txt_t *txt = hsk_dns_txt_alloc();
+
+  if (!txt) {
+    hsk_dns_rr_free(rr);
+    return false;
+  }
+
+  txt->data_len = strlen(text);
+  strcpy((char *)&txt->data[0], text);
+
+  hsk_dns_txts_push(&rd->txts, txt);
+  hsk_dns_rrs_push(an, rr);
+  return true;
+}
+
+static bool
+hsk_hesiod_txt_push_int(char *name, uint64_t n, hsk_dns_rrs_t *an) {
+  char height[16];
+  sprintf(height, "%lld", n);
+  return hsk_hesiod_txt_push(name, height,an);
+}
+
+static bool
+hsk_hesiod_txt_push_hash(char *name, uint8_t *data, hsk_dns_rrs_t *an) {
+  char hash[65];
+  for (int i = 0; i < 32; i++)
+    sprintf(&hash[i * 2], "%02x", data[i]);
+  return hsk_hesiod_txt_push(name, hash, an);
+}
+
+static bool
+hsk_hesiod_resolve_chain(
+  char *name,
+  hsk_chain_t *chain,
+  hsk_dns_rrs_t *an
+) {
+  if (!hsk_hesiod_txt_push_int("height.tip.chain.hnsd.", chain->height, an))
+    return false;
+
+  if (!hsk_hesiod_txt_push_hash("hash.tip.chain.hnsd.", chain->tip->hash, an))
+    return false;
+
+  return true;
+}
+
+static bool
+hsk_hesiod_resolve_pool(
+  char *name,
+  hsk_pool_t *pool,
+  hsk_dns_rrs_t *an
+) {
+  return false;
+}
+
+hsk_dns_msg_t *
+hsk_hesiod_resolve(hsk_dns_req_t *req, hsk_ns_t *ns) {
+  if (strcmp(req->tld, "hnsd") != 0) {
+    return NULL;
+  }
+
+  hsk_dns_msg_t *msg = hsk_dns_msg_alloc();
+
+  if (!msg)
+    return NULL;
+
+  msg->flags |= HSK_DNS_AA;
+
+  char module[HSK_DNS_MAX_LABEL + 1];
+  hsk_dns_label_get(req->name, -2, module);
+
+  hsk_dns_rrs_t *an = &msg->an;
+  if (strcmp(module, "chain") == 0) {
+    if (!hsk_hesiod_resolve_chain(req->name, &ns->pool->chain, an))
+      goto fail;
+
+  } else if (strcmp(module, "pool") == 0) {
+    if (!hsk_hesiod_resolve_pool(req->name, ns->pool, an))
+      goto fail;
+
+  } else {
+    goto fail;
+  }
+
+  return msg;
+
+fail:
+  hsk_dns_msg_free(msg);
+  return NULL;
+}

--- a/src/hesiod.c
+++ b/src/hesiod.c
@@ -58,17 +58,33 @@ hsk_hesiod_resolve(hsk_dns_req_t *req, hsk_ns_t *ns) {
   msg->flags |= HSK_DNS_AA;
   hsk_dns_rrs_t *an = &msg->an;
 
-  if (hsk_dns_is_subdomain(req->name, "hash.tip.chain.hnsd."))
-    if (!hsk_hesiod_txt_push_hash("hash.tip.chain.hnsd.", ns->pool->chain.tip->hash, an))
+  if (hsk_dns_is_subdomain(req->name, "hash.tip.chain.hnsd.")) {
+    if (!hsk_hesiod_txt_push_hash("hash.tip.chain.hnsd.",
+                                  ns->pool->chain.tip->hash,
+                                  an))
       goto fail;
+  }
 
-  if (hsk_dns_is_subdomain(req->name, "height.tip.chain.hnsd."))
-    if (!hsk_hesiod_txt_push_u64("height.tip.chain.hnsd.", ns->pool->chain.tip->height, an))
+  if (hsk_dns_is_subdomain(req->name, "height.tip.chain.hnsd.")) {
+    if (!hsk_hesiod_txt_push_u64("height.tip.chain.hnsd.",
+                                 ns->pool->chain.tip->height,
+                                 an))
       goto fail;
+  }
 
-  if (hsk_dns_is_subdomain(req->name, "time.tip.chain.hnsd."))
-    if (!hsk_hesiod_txt_push_u64("time.tip.chain.hnsd.", ns->pool->chain.tip->time, an))
+  if (hsk_dns_is_subdomain(req->name, "time.tip.chain.hnsd.")) {
+    if (!hsk_hesiod_txt_push_u64("time.tip.chain.hnsd.",
+                                 ns->pool->chain.tip->time,
+                                 an))
       goto fail;
+  }
+
+  if (hsk_dns_is_subdomain(req->name, "synced.tip.chain.hnsd.")) {
+    if (!hsk_hesiod_txt_push("synced.tip.chain.hnsd.",
+                             ns->pool->chain.synced ? "true" : "false",
+                             an))
+      goto fail;
+  }
 
   return msg;
 

--- a/src/hesiod.c
+++ b/src/hesiod.c
@@ -11,6 +11,7 @@
 static bool
 hsk_hesiod_txt_push(char *name, char *text, hsk_dns_rrs_t *an) {
   hsk_dns_rr_t *rr = hsk_dns_rr_create(HSK_DNS_TXT);
+  rr->class = HSK_DNS_HS;
 
   if (!rr)
     return false;

--- a/src/hesiod.h
+++ b/src/hesiod.h
@@ -1,0 +1,10 @@
+#ifndef _HSK_hesiod_
+#define _HSK_hesiod_
+
+#include "dns.h"
+#include "req.h"
+
+hsk_dns_msg_t *
+hsk_hesiod_resolve(hsk_dns_req_t *req, hsk_ns_t *ns);
+
+#endif

--- a/src/ns.c
+++ b/src/ns.c
@@ -331,7 +331,7 @@ hsk_ns_onrecv(
   // Hesiod class is used for local text queries of internal metadata
   if (req->class == HSK_DNS_HS
     && req->type == HSK_DNS_TXT
-    && req->labels >= 2) {
+  ) {
     should_cache = false;
 
     hsk_addr_t address;

--- a/src/pool.c
+++ b/src/pool.c
@@ -843,6 +843,7 @@ hsk_peer_init(hsk_peer_t *peer, hsk_pool_t *pool, bool encrypted) {
 
   peer->id = pool->peer_id++;
   memset(peer->host, 0, sizeof(peer->host));
+  memset(peer->agent, 0, sizeof(peer->agent));
   hsk_addr_init(&peer->addr);
   peer->state = HSK_STATE_DISCONNECTED;
   memset(peer->read_buffer, 0, HSK_BUFFER_SIZE);
@@ -1316,6 +1317,7 @@ hsk_peer_handle_version(hsk_peer_t *peer, const hsk_version_msg_t *msg) {
 
   hsk_peer_log(peer, "received version: %s (%u)\n", msg->agent, msg->height);
   peer->height = (int64_t)msg->height;
+  strcpy(peer->agent, msg->agent);
 
   hsk_timedata_add(&pool->td, &peer->addr, msg->time);
   hsk_addrman_mark_ack(&pool->am, &peer->addr, msg->services);

--- a/src/pool.h
+++ b/src/pool.h
@@ -59,6 +59,7 @@ typedef struct hsk_peer_s {
   hsk_brontide_t *brontide;
   uint64_t id;
   char host[HSK_MAX_HOST];
+  char agent[255];
   hsk_addr_t addr;
   int state;
   uint8_t read_buffer[HSK_BUFFER_SIZE];

--- a/src/utils.c
+++ b/src/utils.c
@@ -88,7 +88,11 @@ hsk_ymd(uint32_t *year, uint32_t *month, uint32_t *day) {
 
 uint32_t
 hsk_random(void) {
-  return _HSK_RANDOM();
+  // RAND_MAX may be only 0x7fff on Windows.
+  // Double up to guarantee 32 bits of randomness.
+  // https://learn.microsoft.com/en-us/cpp/c-runtime-library/rand-max
+  uint32_t n = _HSK_RANDOM();
+  return (n << 16) ^ _HSK_RANDOM();
 }
 
 uint64_t

--- a/test/base32-test.c
+++ b/test/base32-test.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <stdio.h>
 
 #include "base32.h"
 

--- a/test/dns-test.c
+++ b/test/dns-test.c
@@ -1,0 +1,27 @@
+#include <assert.h>
+#include <stdio.h>
+
+#include "dns.h"
+
+static void
+test_hsk_dns_is_subdomain() {
+  assert(hsk_dns_is_subdomain(".", "com."));
+  assert(hsk_dns_is_subdomain("com.", "com."));
+
+  assert(!hsk_dns_is_subdomain("com.", "xcom."));
+  assert(hsk_dns_is_subdomain("com.", "x.com."));
+
+  assert(hsk_dns_is_subdomain("com.", "google.com."));
+  assert(!hsk_dns_is_subdomain("google.com.", "com."));
+  assert(hsk_dns_is_subdomain("google.com.", "mail.google.com."));
+  assert(hsk_dns_is_subdomain("com.", "mail.google.com."));
+  assert(hsk_dns_is_subdomain("com.", "images.mail.google.com."));
+  assert(hsk_dns_is_subdomain("mail.google.com.", "images.mail.google.com."));
+  assert(!hsk_dns_is_subdomain("images.mail.google.com.", "mail.google.com."));
+}
+
+void
+test_dns() {
+  printf(" test_hsk_dns_name_cmp\n");
+  test_hsk_dns_is_subdomain();
+}

--- a/test/hnsd-test.c
+++ b/test/hnsd-test.c
@@ -18,6 +18,9 @@ main() {
   printf("test_base32\n");
   test_base32();
 
+  printf("test_dns\n");
+  test_dns();
+
   printf("test_resource\n");
   test_resource();
 

--- a/test/hnsd-test.h
+++ b/test/hnsd-test.h
@@ -5,6 +5,9 @@ void
 test_base32();
 
 void
+test_dns();
+
+void
 test_resource();
 
 #endif

--- a/test/resource-test.c
+++ b/test/resource-test.c
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <stdio.h>
 
 #include "resource.h"
 


### PR DESCRIPTION
Built on top of https://github.com/handshake-org/hnsd/pull/101 waiting for review and merge

See original idea in https://github.com/handshake-org/hsd/issues/443

## API schema

The HS API can be thought of like a single JSON object:

```
.: {
  hnsd: {
    chain: {
      tip: {
        hash:   `32 byte hex string`,
        height: `unsigned int`,
        time:   `unsigned int`
      },
      synced:   `boolean`,
      progress: `float`
    },
    pool: {
      size:     `unsigned int`,
      [id].peers: [
        {
          host:  `string`,
          agent: `string`,
          headers `unsigned int`,
          proofs: `unsigned int`,
          state: `string`
        }
      ]
    }
  }
}
```

The object properties and sub-objects are addressed like a sort of backwards JSON notation, with an implied "wildcard" (`*`) prepended to the query string. So querying `sub.domain.` is equivalent to querying `*.sub.domain` and all the data at or below that level will be returned.

## Examples

### Retrieve the entire object:

```
$ dig @127.0.0.1 -p 5349 HS TXT .

...

;; ANSWER SECTION:
hash.tip.chain.hnsd.    0       HS      TXT     "00000000000000060a961fd96887778c460388ff84412d2a74f802a91a13909b"
height.tip.chain.hnsd.  0       HS      TXT     "145806"
time.tip.chain.hnsd.    0       HS      TXT     "1668109101"
synced.chain.hnsd.      0       HS      TXT     "true"
progress.chain.hnsd.    0       HS      TXT     "1.000000"
size.pool.hnsd.         0       HS      TXT     "3"
host.0.peers.pool.hnsd. 0       HS      TXT     "107.152.33.71:44806"
agent.0.peers.pool.hnsd. 0      HS      TXT     "/hsd:3.0.1/"
headers.0.peers.pool.hnsd. 0    HS      TXT     "145806"
proofs.0.peers.pool.hnsd. 0     HS      TXT     "42"
state.0.peers.pool.hnsd. 0      HS      TXT     "HSK_STATE_HANDSHAKE"
host.1.peers.pool.hnsd. 0       HS      TXT     "94.250.201.213:39001"
agent.1.peers.pool.hnsd. 0      HS      TXT     ""
headers.1.peers.pool.hnsd. 0    HS      TXT     "0"
proofs.1.peers.pool.hnsd. 0     HS      TXT     "0"
state.1.peers.pool.hnsd. 0      HS      TXT     "HSK_STATE_CONNECTING"
host.2.peers.pool.hnsd. 0       HS      TXT     "202.61.245.13:39001"
agent.2.peers.pool.hnsd. 0      HS      TXT     ""
headers.2.peers.pool.hnsd. 0    HS      TXT     "0"
proofs.2.peers.pool.hnsd. 0     HS      TXT     "0"
state.2.peers.pool.hnsd. 0      HS      TXT     "HSK_STATE_CONNECTING"
```

### Retrieve the chain sync progress only:

```
$ dig @127.0.0.1 -p 5349 HS TXT progress.chain.hnsd. +short

"1.000000"
```

### Retrieve data about chain tip block header:

```
$ dig @127.0.0.1 -p 5349 HS TXT tip.chain.hnsd.

...

;; ANSWER SECTION:
hash.tip.chain.hnsd.    0       HS      TXT     "00000000000000017c9ad1944a32af23819542842c30ebd5c7b99a939c4ba79b"
height.tip.chain.hnsd.  0       HS      TXT     "144656"
time.tip.chain.hnsd.    0       HS      TXT     "1667414685"
```