### PR TITLE
chain: fix hsk_chain_maybe_sync

### DIFF
--- a/src/chain.c
+++ b/src/chain.c
@@ -262,12 +262,6 @@ hsk_chain_maybe_sync(hsk_chain_t *chain) {
 
   int64_t now = hsk_timedata_now(chain->td);
 
-  if (now < HSK_LAUNCH_DATE) {
-    hsk_chain_log(chain, "chain is fully synced\n");
-    chain->synced = true;
-    return;
-  }
-
   if (HSK_USE_CHECKPOINTS) {
     if (chain->height < HSK_LAST_CHECKPOINT)
       return;

--- a/src/constants.h
+++ b/src/constants.h
@@ -81,7 +81,6 @@ static const uint8_t HSK_CHAINWORK[32] = {
 #define HSK_USE_CHECKPOINTS true
 #define HSK_LAST_CHECKPOINT 1008          // Used for maybe_sync, no block hash
 #define HSK_MAX_TIP_AGE (24 * 60 * 60)
-#define HSK_LAUNCH_DATE 0xffffffff        // Used for maybe_sync, not useful
 
 #elif HSK_NETWORK == HSK_TESTNET
 
@@ -136,7 +135,6 @@ static const uint8_t HSK_CHAINWORK[32] = {
 #define HSK_USE_CHECKPOINTS false
 #define HSK_LAST_CHECKPOINT 0
 #define HSK_MAX_TIP_AGE (2 * 7 * 24 * 60 * 60)
-#define HSK_LAUNCH_DATE 0xffffffff
 
 #elif HSK_NETWORK == HSK_REGTEST
 
@@ -180,7 +178,6 @@ static const uint8_t HSK_CHAINWORK[32] = {
 #define HSK_USE_CHECKPOINTS false
 #define HSK_LAST_CHECKPOINT 0
 #define HSK_MAX_TIP_AGE (2 * 7 * 24 * 60 * 60)
-#define HSK_LAUNCH_DATE 0xffffffff
 
 #elif HSK_NETWORK == HSK_SIMNET
 
@@ -224,7 +221,6 @@ static const uint8_t HSK_CHAINWORK[32] = {
 #define HSK_USE_CHECKPOINTS false
 #define HSK_LAST_CHECKPOINT 0
 #define HSK_MAX_TIP_AGE (2 * 7 * 24 * 60 * 60)
-#define HSK_LAUNCH_DATE 0xffffffff
 
 #else
 


### PR DESCRIPTION
This is a small PR to fix `hsk_chain_maybe_sync`. When this function is called the first time, it sets `chain->synced = true`. So all sync checking logic afterwards gets skipped:

https://github.com/handshake-org/hnsd/blob/cf19505f3c0b473e7da800165e42fca36c649019/src/chain.c#L265-L269


If you were wondering why you see this in the logs it's because of that ^. 

```
chain (0): chain is fully synced
```

I think this was just old code before mainnet launch. After removing it, hnsd will refuse to answer requests until it's fully synced which is neat! Answering queries without waiting to sync is problematic due to cache poisoning from old records ... etc. Fingertip mitigates that by trying to guess the synced state but hnsd should ideally do it.

```
pool: sending proof request for: proofofconcept.
pool: cannot send proof request: chain not synced.
```