### PR TITLE
ci: build with sanitizer to check for memory issues

### DIFF
--- a/.github/workflows/memory-sanitizer.yaml
+++ b/.github/workflows/memory-sanitizer.yaml
@@ -1,0 +1,34 @@
+name: Memory Sanitizer
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Ubuntu Install Deps
+        run: sudo apt-get update && sudo apt-get install -y libunbound-dev
+
+      - name: Build
+        run: ./autogen.sh && ./configure --with-network=regtest --with-sanitizers=address && make
+
+      - name: Unit Tests
+        run: ./test_hnsd
+
+      - name: Setup Integration
+        uses: actions/setup-node@v3.5.1
+        with:
+          node-version: 18
+
+      - name: Integration Tests
+        working-directory: ./integration
+        run: |
+          npm install
+          npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Ubuntu Install Deps
         if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get install -y libunbound-dev
+        run: sudo apt-get update && sudo apt-get install -y libunbound-dev
 
       - name: Build
         run: ./autogen.sh && ./configure --with-network=regtest && make

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,6 @@
 AUTOMAKE_OPTIONS = foreign
-CFLAGS = -Wall -Wno-unused-function -std=gnu11 -O2
-LDFLAGS =
+CFLAGS = -Wall -Wno-unused-function -std=gnu11 -O2 $(SANITIZER_FLAGS)
+LDFLAGS = $(SANITIZER_FLAGS)
 
 SUBDIRS = uv
 

--- a/configure.ac
+++ b/configure.ac
@@ -160,6 +160,15 @@ AC_ARG_WITH([unbound],
   [libunbound_path=$withval],
   [libunbound_path=yes])
 
+AC_ARG_WITH([sanitizers],
+  [AS_HELP_STRING(
+    [--with-sanitizers]
+    [comma separated list of extra sanitizers to build with (default is none)]
+  )],
+  [SANITIZER_FLAGS="-g -fsanitize=$withval"])
+
+AC_SUBST(SANITIZER_FLAGS, ${SANITIZER_FLAGS})
+
 AC_CHECK_TYPES([__int128])
 
 AC_MSG_CHECKING([for __builtin_expect])

--- a/integration/test/config-test.js
+++ b/integration/test/config-test.js
@@ -1,0 +1,112 @@
+/* eslint-env mocha */
+/* eslint prefer-arrow-callback: "off" */
+/* eslint max-len: "off" */
+/* eslint no-return-assign: "off" */
+
+'use strict';
+
+const assert = require('bsert');
+const {version} = require('../package.json');
+
+const TestUtil = require('../test-util');
+const util = new TestUtil();
+
+describe('Configuration', function() {
+  this.timeout(10000);
+
+  before(async () => {
+    await util.open();
+  });
+
+  after(async () => {
+    await util.close();
+  });
+
+  function waitForStartFailure(expectedMsg, expectedCode) {
+    return new Promise((resolve, reject) => {
+      let gotMsg = false;
+      let gotCode = false;
+      let error = null;
+
+      function maybeResolve() {
+        if (!gotMsg || !gotCode)
+          return;
+
+        if (error)
+          reject(error);
+        else
+          resolve();
+      }
+
+      function fail(actual, expected) {
+        error = new assert.AssertionError({
+          message: 'hnsd start failure with unexpected output',
+          actual,
+          expected,
+          operator: 'equal'
+        });
+      }
+
+      function handleErr(msg) {
+        if (!msg.match(expectedMsg))
+          fail(msg, expectedMsg);
+        gotMsg = true;
+        maybeResolve();
+      }
+
+      function handleClose(code) {
+        if (code !== expectedCode)
+          fail(code, expectedCode);
+        gotCode = true;
+        maybeResolve();
+      }
+
+      util.once('stderr', handleErr);
+      util.once('close', handleClose);
+    });
+  }
+
+  describe('--agent', function () {
+    it('should have default user agent', async () => {
+      await util.generate(1);
+      await util.waitForSync();
+
+      const peer = util.node.pool.peers.head();
+      assert.strictEqual(peer.agent, `/hnsd:${version}/`);
+      await util.closeHNSD();
+    });
+
+    it('should fail to start with too-long agent', async () => {
+      const waiter = waitForStartFailure(
+        /failed adding user agent/,
+        3 // HSK_EBADARGS
+      );
+
+      const agent = 'x'.repeat(255 - `/hnsd:${version}/`.length);
+      await util.restartHNSD(['-a', agent]);
+      await waiter;
+    });
+
+    it('should fail to start with backslash-containing agent', async () => {
+      const waiter = waitForStartFailure(
+        /failed adding user agent/,
+        3 // HSK_EBADARGS
+      );
+
+      const agent = 'beacon/browser/verifies/dane';
+      await util.restartHNSD(['-a', agent]);
+      await waiter;
+    });
+
+    it('should have custom user agent', async () => {
+      const agent = 'x'.repeat(255 - `/hnsd:${version}/`.length - 1);
+      await util.restartHNSD(['-a', agent]);
+      await util.generate(1);
+      await util.waitForSync();
+
+      const peer = util.node.pool.peers.head();
+      assert.strictEqual(peer.agent, `/hnsd:${version}/${agent}/`);
+      await util.closeHNSD();
+    });
+  });
+});

--- a/src/pool.c
+++ b/src/pool.c
@@ -302,14 +302,19 @@ hsk_pool_set_agent(hsk_pool_t *pool, const char *user_agent) {
   if (!user_agent)
     return true;
 
+  if (strchr(user_agent, '/'))
+    return false;
+
   size_t len = strlen(pool->user_agent);
   len += strlen(user_agent);
+  len += 1; // terminal "/"
 
   // Agent size in p2p version message is 1 byte
-  if (len > 0xff)
+  if (len > HSK_MAX_AGENT)
     return false;
 
   pool->user_agent = strcat(pool->user_agent, user_agent);
+  pool->user_agent = strcat(pool->user_agent, "/");
 
   return true;
 }

--- a/src/pool.h
+++ b/src/pool.h
@@ -27,6 +27,7 @@
 #define HSK_STATE_READING 4
 #define HSK_STATE_HANDSHAKE 5
 #define HSK_STATE_DISCONNECTING 6
+#define HSK_MAX_AGENT 255
 
 /*
  * Types
@@ -59,7 +60,7 @@ typedef struct hsk_peer_s {
   hsk_brontide_t *brontide;
   uint64_t id;
   char host[HSK_MAX_HOST];
-  char agent[255];
+  char agent[HSK_MAX_AGENT];
   hsk_addr_t addr;
   int state;
   uint8_t read_buffer[HSK_BUFFER_SIZE];


### PR DESCRIPTION
Closes #104 

Built off https://github.com/handshake-org/hnsd/pull/99 which fixes some memory leaks.

This PR adds a flag `configure --with-sanitizers=<sanitizers>` where `<sanitizers>` is a comma separated list of sanitizers like `address,leak`. I borrowed the configure logic from Bitcoin Core: https://github.com/bitcoin/bitcoin/blob/38d06e1561013f4ca845fd5ba6ffcc64de67f9c0/configure.ac#L315-L319

The flag is added to CI integration tests. I intentionally committed a few memory violations and then patched them to demonstrate to reviewers how this will look (it's a bit of a mess, but works by throwing errors in the bmocha suite).

example memory leak detected: https://github.com/handshake-org/hnsd/actions/runs/3527082949/jobs/5915748956#step:8:645

example use-after-free detected: https://github.com/handshake-org/hnsd/actions/runs/3527133001/jobs/5915851526#step:8:34