### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ You're a Linux user so you probably already know what to do. Make sure you have
 git, autotools, libtool, and unbound installed via whatever package manager
 your OS uses.
 You can install these dependencies on any Ubuntu/Debian style linux using
-`sudo apt install -y autotools-dev libtool libunbound-dev`
+`sudo apt install -y autotools-dev libtool libunbound-dev build-essential`
 
 ### Windows
 


### PR DESCRIPTION
Default ubuntu image in AWS did not have build tools already installed. I needed to run "sudo apt install -y build-essential" in order to build hnsd