### PR TITLE
Fix an error in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ DLLs to the hnsd directory, etc.
 ## Cloning
 
 ``` sh
-$ git clone git://github.com/handshake-org/hnsd.git
+$ git clone https://github.com/handshake-org/hnsd.git
 $ cd hnsd
 ```
 


### PR DESCRIPTION
GitHub is no longer providing the old unencrypted git clone, instead it must be cloned by SSH or HTTPS