### PR TITLE
Add Docker workflow for building and pushing images

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -1,0 +1,60 @@
+name: Docker
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - '*'
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ secrets.DOCKERHUB_ACCOUNT }}/hnsd
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable=${{ github.ref != 'refs/heads/master' }}
+            type=edge
+          flavor: |
+            latest=false
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/test-windows.yaml
+++ b/.github/workflows/test-windows.yaml
@@ -33,12 +33,13 @@ jobs:
         run: ./test_hnsd
 
       - name: Setup Integration
-        uses: actions/setup-node@v3.5.1
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: lts/*
+          check-latest: true
 
       - name: Integration Tests
         working-directory: ./integration
-        run:  |
-              npm install
-              npm run test
+        run: |
+          npm install
+          npm run test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,9 +31,10 @@ jobs:
         run: ./test_hnsd
 
       - name: Setup Integration
-        uses: actions/setup-node@v3.5.1
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: lts/*
+          check-latest: true
 
       - name: Integration Tests
         working-directory: ./integration


### PR DESCRIPTION
The images will be published to [ghcr.io](https://github.com/handshake-org/hnsd/packages) and [docker hub](https://hub.docker.com/r/handshakeorg/hnsd).

Each new git tag will generate/replace:
Example tag: `v1.2.3`
* handshake-org/hnsd:latest
* handshake-org/hnsd:1.2.3
* handshake-org/hnsd:1.2
* handshake-org/hnsd:1

Merges to `master` generates:
* handshake-org/hnsd:edge