### PR TITLE
Add workflow for updating tld.h file

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -29,19 +29,10 @@ jobs:
       - name: Install dependencies (hsd)
         run: npm --prefix=hs-names install hsd@^5
 
-      - name: Download (tlds-alpha-by-domain.txt)
-        uses: wei/wget@v1
-        with:
-          args: -O hs-names/data/tlds-alpha-by-domain.txt https://data.iana.org/TLD/tlds-alpha-by-domain.txt
-
-      - name: Download (root.zone)
-        uses: wei/wget@v1
-        with:
-          args: -O hs-names/data/root.zone https://www.internic.net/domain/root.zone
-
       - name: Build
         run: |
           cd hs-names
+          ./download
           # Workaround for https://github.com/chjj/bns/issues/41
           sed -i '/ZONEMD/d' data/root.zone
           ./zone.js

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,9 +1,9 @@
-name: Update
+name: Regenerate tld.h
 
 on: workflow_dispatch
 
 jobs:
-  update:
+  generate:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -1,0 +1,90 @@
+name: Update
+
+on: workflow_dispatch
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup nodejs
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Checkout repository (hnsd)
+        uses: actions/checkout@v4
+        with:
+          path: hnsd
+
+      - name: Checkout repository (hs-names)
+        uses: actions/checkout@v4
+        with:
+          repository: handshake-org/hs-names
+          path: hs-names
+
+      - name: Install dependencies (hs-names)
+        run: npm --prefix=hs-names install
+
+      - name: Install dependencies (hsd)
+        run: npm --prefix=hs-names install hsd@^5
+
+      - name: Download (tlds-alpha-by-domain.txt)
+        uses: wei/wget@v1
+        with:
+          args: -O hs-names/data/tlds-alpha-by-domain.txt https://data.iana.org/TLD/tlds-alpha-by-domain.txt
+
+      - name: Download (root.zone)
+        uses: wei/wget@v1
+        with:
+          args: -O hs-names/data/root.zone https://www.internic.net/domain/root.zone
+
+      - name: Build
+        run: |
+          cd hs-names
+          # Workaround for https://github.com/chjj/bns/issues/41
+          sed -i '/ZONEMD/d' data/root.zone
+          ./zone.js
+          ./zone-build.js
+
+      - name: Commit/PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const branch = `update-${new Date().getTime()}`;
+            const ref = `refs/heads/${branch}`;
+
+            await github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref,
+              sha: context.sha
+            });
+
+            const fileOptions = {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              path: 'src/tld.h',
+            };
+
+            const file = await github.rest.repos.getContent({
+              ...fileOptions,
+              ref
+            });
+
+            await github.rest.repos.createOrUpdateFileContents({
+              ...fileOptions,
+              message: 'Update tld.h',
+              content: Buffer.from(fs.readFileSync('hs-names/build/tld.h')).toString('base64'),
+              sha: file.data.sha,
+              branch
+            });
+
+            await github.rest.pulls.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: 'Update tld.h',
+              head: branch,
+              base: 'master'
+            });


### PR DESCRIPTION
This PR adds a GitHub action script that will:
* Checkout and install [hs-names](https://github.com/handshake-org/hs-names) with its dependencies
* Download the TLD and zone file from ICANN
* Update the `src/tld.h`
* Commit and create a PR

There's no automatic trigger for this action. It needs to be manually triggered from the [actions page](https://github.com/handshake-org/hnsd/actions/workflows/update.yml).