### PR TITLE
Add logging of urkel tree roots during synchronisation.

### DIFF
--- a/integration/test/hesiod-test.js
+++ b/integration/test/hesiod-test.js
@@ -111,7 +111,7 @@ describe('Hesiod', function() {
       });
 
       const {answer} = await util.resolver.resolve(qs);
-      assert.strictEqual(answer.length, 5);
+      assert.strictEqual(answer.length, 6);
 
       assert.strictEqual(answer[0].name, 'hash.tip.chain.hnsd.');
       assert.strictEqual(answer[0].data.txt[0], util.node.chain.tip.hash.toString('hex'));
@@ -120,14 +120,17 @@ describe('Hesiod', function() {
       assert.strictEqual(answer[1].data.txt[0], String(util.node.chain.tip.height));
       assert.strictEqual(answer[1].data.txt[0], '6000');
 
-      assert.strictEqual(answer[2].name, 'time.tip.chain.hnsd.');
-      assert.strictEqual(answer[2].data.txt[0], String(util.node.chain.tip.time));
+      assert.strictEqual(answer[2].name, 'name_root.tip.chain.hnsd.');
+      assert.strictEqual(answer[2].data.txt[0], util.node.chain.tip.treeRoot.toString('hex'));
 
-      assert.strictEqual(answer[3].name, 'synced.chain.hnsd.');
-      assert.strictEqual(answer[3].data.txt[0], 'true');
+      assert.strictEqual(answer[3].name, 'time.tip.chain.hnsd.');
+      assert.strictEqual(answer[3].data.txt[0], String(util.node.chain.tip.time));
 
-      assert.strictEqual(answer[4].name, 'progress.chain.hnsd.');
-      assert.strictEqual(answer[4].data.txt[0], '1.000000');
+      assert.strictEqual(answer[4].name, 'synced.chain.hnsd.');
+      assert.strictEqual(answer[4].data.txt[0], 'true');
+
+      assert.strictEqual(answer[5].name, 'progress.chain.hnsd.');
+      assert.strictEqual(answer[5].data.txt[0], '1.000000');
     });
   });
 

--- a/src/chain.c
+++ b/src/chain.c
@@ -589,6 +589,8 @@ hsk_chain_add(hsk_chain_t *chain, const hsk_header_t *h) {
   const uint8_t *hash = hsk_header_cache(hdr);
 
   hsk_chain_log(chain, "adding block: %s\n", hsk_hex_encode32(hash));
+  hsk_chain_log(chain, "tree_root %s timestamp %d \n",
+      hsk_hex_encode32(hdr->name_root), hdr->time);
 
   int64_t now = hsk_timedata_now(chain->td);
 

--- a/src/hesiod.c
+++ b/src/hesiod.c
@@ -135,6 +135,11 @@ hsk_hesiod_resolve(hsk_dns_req_t *req, hsk_ns_t *ns) {
       goto fail;
   }
 
+  if (hsk_dns_is_subdomain(req->name, "name_root.tip.chain.hnsd.")) {
+    if (!hsk_hesiod_txt_push_hash("name_root.tip.chain.hnsd.", ns->pool->chain.tip->name_root, an))
+      goto fail;
+  }
+
   if (hsk_dns_is_subdomain(req->name, "time.tip.chain.hnsd.")) {
     if (!hsk_hesiod_txt_push_u64("time.tip.chain.hnsd.",
                                  ns->pool->chain.tip->time,


### PR DESCRIPTION
Added logging of urkel tree roots during synchronisation.
Also added additional output to hesiod query.
Used in stateless DANE: https://github.com/randomlogin/sane 