### PR TITLE
rs: do not strip authority section in response

### DIFF
--- a/src/rs.c
+++ b/src/rs.c
@@ -458,13 +458,8 @@ hsk_rs_respond(
   if (result->secure && !result->bogus)
     msg->flags |= HSK_DNS_AD;
 
-  // Strip out non-answer sections.
+  // Strip out additional section
   if (msg->an.size > 0) {
-    while (msg->ns.size > 0) {
-      hsk_dns_rr_t *rr = hsk_dns_rrs_pop(&msg->ns);
-      hsk_dns_rr_free(rr);
-    }
-
     while (msg->ar.size > 0) {
       hsk_dns_rr_t *rr = hsk_dns_rrs_pop(&msg->ar);
       hsk_dns_rr_free(rr);


### PR DESCRIPTION
Fixes https://github.com/buffrr/letsdane/issues/1

Recursive resolvers should return the NSEC record in the AUTHORITY section for successful verification of wildcard records.  Trying to do so right now (in both hsd and hnsd) fail with `noqname proof not found`.

more info: https://datatracker.ietf.org/doc/html/rfc5155#section-8.8

### Live example

`*.home.htools` is a wildcard TLSA record in zone `htools` at 129.153.177.220.

Start hnsd with:
```sh
./hnsd -p 2 -r 127.0.0.1:9592 -n 127.0.0.1:9591 -t -x ~/.hnsd
```

Without this PR:
```
❯ delv @127.0.0.1 -p 9592 -a ~/.hsd-ksk _443._tcp.home.htools TLSA +rtrace +vtrace +nosplit
;; fetch: _443._tcp.home.htools/TLSA
;; validating _443._tcp.home.htools/TLSA: starting
;; validating _443._tcp.home.htools/TLSA: attempting positive response validation
;; fetch: htools/DNSKEY
;; validating htools/DNSKEY: starting
;; validating htools/DNSKEY: attempting positive response validation
;; fetch: htools/DS
;; validating htools/DS: starting
;; validating htools/DS: attempting positive response validation
;; fetch: ./DNSKEY
;; validating ./DNSKEY: starting
;; validating ./DNSKEY: attempting positive response validation
;; validating ./DNSKEY: verify rdataset (keyid=35215): success
;; validating ./DNSKEY: marking as secure (DS)
;; validating htools/DS: in fetch_callback_dnskey
;; validating htools/DS: keyset with trust secure
;; validating htools/DS: resuming validate
;; validating htools/DS: verify rdataset (keyid=60944): success
;; validating htools/DS: marking as secure, noqname proof not needed
;; validating htools/DNSKEY: in fetch_callback_ds
;; validating htools/DNSKEY: dsset with trust secure
;; validating htools/DNSKEY: verify rdataset (keyid=24809): success
;; validating htools/DNSKEY: marking as secure (DS)
;; validating _443._tcp.home.htools/TLSA: in fetch_callback_dnskey
;; validating _443._tcp.home.htools/TLSA: keyset with trust secure
;; validating _443._tcp.home.htools/TLSA: resuming validate
;; validating _443._tcp.home.htools/TLSA: verify rdataset (keyid=24809): from wildcard
;; validating _443._tcp.home.htools/TLSA: looking for noqname proof
;; validating _443._tcp.home.htools/TLSA: noqname proof not found
;; no valid NSEC resolving '_443._tcp.home.htools/TLSA/IN': 127.0.0.1#9592
;; resolution failed: no valid NSEC
```

With this PR:
```
❯ delv @127.0.0.1 -p 9592 -a ~/.hsd-ksk _443._tcp.home.htools TLSA +rtrace +vtrace +nosplit
;; fetch: _443._tcp.home.htools/TLSA
;; validating _443._tcp.home.htools/TLSA: starting
;; validating _443._tcp.home.htools/TLSA: attempting positive response validation
;; fetch: htools/DNSKEY
;; validating htools/DNSKEY: starting
;; validating htools/DNSKEY: attempting positive response validation
;; fetch: htools/DS
;; validating htools/DS: starting
;; validating htools/DS: attempting positive response validation
;; fetch: ./DNSKEY
;; validating ./DNSKEY: starting
;; validating ./DNSKEY: attempting positive response validation
;; validating ./DNSKEY: verify rdataset (keyid=35215): success
;; validating ./DNSKEY: marking as secure (DS)
;; validating htools/DS: in fetch_callback_dnskey
;; validating htools/DS: keyset with trust secure
;; validating htools/DS: resuming validate
;; validating htools/DS: verify rdataset (keyid=60944): success
;; validating htools/DS: marking as secure, noqname proof not needed
;; validating htools/DNSKEY: in fetch_callback_ds
;; validating htools/DNSKEY: dsset with trust secure
;; validating htools/DNSKEY: verify rdataset (keyid=24809): success
;; validating htools/DNSKEY: marking as secure (DS)
;; validating _443._tcp.home.htools/TLSA: in fetch_callback_dnskey
;; validating _443._tcp.home.htools/TLSA: keyset with trust secure
;; validating _443._tcp.home.htools/TLSA: resuming validate
;; validating _443._tcp.home.htools/TLSA: verify rdataset (keyid=24809): from wildcard
;; validating _443._tcp.home.htools/TLSA: looking for noqname proof
;;   validating _atproto.home.htools/NSEC: starting
;;   validating _atproto.home.htools/NSEC: attempting positive response validation
;;   validating _atproto.home.htools/NSEC: keyset with trust secure
;;   validating _atproto.home.htools/NSEC: verify rdataset (keyid=24809): success
;;   validating _atproto.home.htools/NSEC: marking as secure, noqname proof not needed
;; validating _443._tcp.home.htools/TLSA: in validator_callback_nsec
;; validating _443._tcp.home.htools/TLSA: looking for relevant NSEC
;; validating _443._tcp.home.htools/TLSA: nsec range ok
;; validating _443._tcp.home.htools/TLSA: resuming validate_nx
;; validating _443._tcp.home.htools/TLSA: marking as secure, noqname proof found
; fully validated
_443._tcp.home.htools.  279     IN      TLSA    3 1 1 EFB386BDFB86E2249988443E79123773662CE0F4530BAC08732FFF4E5489262F
_443._tcp.home.htools.  279     IN      RRSIG   TLSA 13 2 3600 20240314000000 20240222000000 24809 htools. +HAPmPsy7X2QSveQMKg7XTZGNyjsQ2OsPFMBwQE0e9tD/PYk5ZXnjvWBY+RTCszzgvh/pdKJNby6r1EXb4PZOg==
```