### PR TITLE
ci: Lock npm version and add brew prefix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,14 +18,16 @@ jobs:
 
       - name: MacOS Install Deps
         if: matrix.os == 'macos-latest'
-        run: brew install automake autoconf libtool unbound
+        run: |
+          brew install automake autoconf libtool unbound
+          echo "CONFIGURE_EXTRA_ARGS=--with-unbound=$(brew --prefix unbound)" >> $GITHUB_ENV
 
       - name: Ubuntu Install Deps
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install -y libunbound-dev
 
       - name: Build
-        run: ./autogen.sh && ./configure --with-network=regtest && make
+        run: ./autogen.sh && ./configure --with-network=regtest $CONFIGURE_EXTRA_ARGS && make
 
       - name: Unit Tests
         run: ./test_hnsd

--- a/integration/package.json
+++ b/integration/package.json
@@ -9,6 +9,6 @@
   "dependencies": {
     "bmocha": "^2.1.5",
     "bsert": "0.0.10",
-    "hsd": "^4.0.1"
+    "hsd": "^8.0.0"
   }
 }


### PR DESCRIPTION
Fix actions to stop the consistent failures. Bumps hsd to the latest version to stop compilation errors on node versions newer than 20